### PR TITLE
fix: update docker-compose to use image built from Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -292,7 +292,7 @@ services:
       SOCIAL_AUTH_EDX_OIDC_URL_ROOT: http://edx.devstack.lms:18000/oauth2
       ENABLE_DJANGO_TOOLBAR: 1
       DJANGO_WATCHMAN_TIMEOUT: 30
-    image: edxops/credentials:${OPENEDX_RELEASE:-latest}
+    image: openedx/credentials-dev:${OPENEDX_RELEASE:-latest}
     networks:
       default:
         aliases:


### PR DESCRIPTION
The image pulled and used in devstack by default continues to be the container built from our legacy ansible configuration. This means that developers aren't testing and developing against the same image deployed in Stage and Production.

Additionally, the legacy image is running older versions of Node and npm (Node 16 and npm 8.x, instead of Node 18 and npm 9.9.x).

This PR updates devstack to use the image built from the Credentials dockerfile, which is built after every merge to the `master` branch.

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
