### PR TITLE
fix: update default node in devstack MFE's to v 18.x

### DIFF
--- a/microfrontend.yml
+++ b/microfrontend.yml
@@ -19,6 +19,6 @@ services:
     command: bash -c 'npm ci || exit 1; while true; do npm start; sleep 2; done'
     stdin_open: true
     tty: true
-    image: node:16
+    image: node:18
     environment:
       - NODE_ENV=development


### PR DESCRIPTION
We are currently installing 16 by default, which is EOL and causing issues with some MFE services in devstack.
