### PR TITLE
Manual upgrades update

### DIFF
--- a/docs/manual_upgrades.rst
+++ b/docs/manual_upgrades.rst
@@ -8,6 +8,31 @@ Please add new instructions to the top, include a date, and make a post in the `
 (If you just need to update your devstack to the latest version of everything, see :doc:`updating_devstack`.)
 
 
+2024-04-29 - Moved Open edX repositories
+****************************************
+
+Several repositories were being deprecated by Open edX (`issue #227 <https://github.com/openedx/public-engineering/issues/227>`_).
+We are forking some of those repositories to keep maintaining them.
+
+If you use any of the following repositories, please make sure to update the remote URLs:
+
+- **edx-analytics-dashboard**::
+
+    git remote set-url origin git@github.com:edx/edx-analytics-dashboard.git
+
+
+- **edx-analytics-data-api**::
+
+    git remote set-url origin git@github.com:edx/edx-analytics-data-api.git
+
+- **edx-analytics-data-api-client**::
+
+    git remote set-url origin git@github.com:edx/edx-analytics-data-api-client.git
+
+
+
+
+
 2024-02-25 - Mongo upgrade from version 4.4 to 5.0
 **************************************************
 

--- a/docs/manual_upgrades.rst
+++ b/docs/manual_upgrades.rst
@@ -8,8 +8,8 @@ Please add new instructions to the top, include a date, and make a post in the `
 (If you just need to update your devstack to the latest version of everything, see :doc:`updating_devstack`.)
 
 
-2024-04-29 - Moved Open edX repositories
-****************************************
+2024-04-29 - Moved Open edX analytics repositories
+**************************************************
 
 Several repositories were being deprecated by Open edX (`issue #227 <https://github.com/openedx/public-engineering/issues/227>`_).
 We are forking some of those repositories to keep maintaining them.

--- a/docs/manual_upgrades.rst
+++ b/docs/manual_upgrades.rst
@@ -16,22 +16,26 @@ We are forking some of those repositories to keep maintaining them.
 
 If you use any of the following repositories, please make sure to update the remote URLs:
 
-- **edx-analytics-dashboard**::
+To update devstack and the local repositories::
 
+    cd /path/to/devstack
+    git pull
+
+    cd ..
+    cd edx-analytics-dashboard
     git remote set-url origin git@github.com:edx/edx-analytics-dashboard.git
+    git pull
 
-
-- **edx-analytics-data-api**::
-
+    cd ..
+    cd edx-analytics-data-api
     git remote set-url origin git@github.com:edx/edx-analytics-data-api.git
+    git pull
 
-- **edx-analytics-data-api-client**::
+If you happen to use `edx-analytics-data-api-client`::
 
+    cd /path/to/edx-analytics-data-api-client
     git remote set-url origin git@github.com:edx/edx-analytics-data-api-client.git
-
-
-
-
+    git pull
 
 2024-02-25 - Mongo upgrade from version 4.4 to 5.0
 **************************************************

--- a/docs/service_list.rst
+++ b/docs/service_list.rst
@@ -93,5 +93,5 @@ Some common service combinations include:
 .. _xqueue: https://github.com/openedx/xqueue
 .. _coursegraph: https://github.com/openedx/edx-platform/tree/master/cms/djangoapps/coursegraph#coursegraph-support
 .. _frontend-app-ora-grading: https://github.com/edx/frontend-app-ora-grading
-.. _insights: https://github.com/openedx/edx-analytics-dashboard
-.. _analyticsapi: https://github.com/openedx/edx-analytics-data-api
+.. _insights: https://github.com/edx/edx-analytics-dashboard
+.. _analyticsapi: https://github.com/edx/edx-analytics-data-api

--- a/repo.sh
+++ b/repo.sh
@@ -28,14 +28,14 @@ repos=(
     "https://github.com/openedx/edx-notes-api.git"
     "https://github.com/openedx/edx-platform.git"
     "https://github.com/openedx/xqueue.git"
-    "https://github.com/openedx/edx-analytics-dashboard.git"
+    "https://github.com/edx/edx-analytics-dashboard.git"
     "https://github.com/openedx/frontend-app-gradebook.git"
     "https://github.com/openedx/frontend-app-learner-dashboard"
     "https://github.com/openedx/frontend-app-learner-record"
     "https://github.com/edx/frontend-app-payment.git"
     "https://github.com/openedx/frontend-app-publisher.git"
-    "https://github.com/openedx/edx-analytics-dashboard.git"
-    "https://github.com/openedx/edx-analytics-data-api.git"
+    "https://github.com/edx/edx-analytics-dashboard.git"
+    "https://github.com/edx/edx-analytics-data-api.git"
 )
 
 non_release_repos=(
@@ -58,14 +58,14 @@ ssh_repos=(
     "git@github.com:openedx/edx-notes-api.git"
     "git@github.com:openedx/edx-platform.git"
     "git@github.com:openedx/xqueue.git"
-    "git@github.com:openedx/edx-analytics-dashboard.git"
+    "git@github.com:edx/edx-analytics-dashboard.git"
     "git@github.com:openedx/frontend-app-gradebook.git"
     "git@github.com:openedx/frontend-app-learner-dashboard.git"
     "git@github.com:openedx/frontend-app-learner-record.git"
     "git@github.com:edx/frontend-app-payment.git"
     "git@github.com:openedx/frontend-app-publisher.git"
-    "git@github.com:openedx/edx-analytics-dashboard.git"
-    "git@github.com:openedx/edx-analytics-data-api.git"
+    "git@github.com:edx/edx-analytics-dashboard.git"
+    "git@github.com:edx/edx-analytics-data-api.git"
 )
 
 non_release_ssh_repos=(


### PR DESCRIPTION
Open edX is deprecating several repositories, [Team Cosmonauts](https://2u-internal.atlassian.net/wiki/spaces/COSMO/overview) is taking ownership of edx-analytics-dashboard, edx-analytics-data-api and edx-analytics-data-api-client to maintain them.