### PR TITLE
chore: Fixed backticks on Manual Upgrades docs

### DIFF
--- a/docs/manual_upgrades.rst
+++ b/docs/manual_upgrades.rst
@@ -31,7 +31,7 @@ To update devstack and the local repositories::
     git remote set-url origin git@github.com:edx/edx-analytics-data-api.git
     git pull
 
-If you happen to use `edx-analytics-data-api-client`::
+If you happen to use ``edx-analytics-data-api-client``::
 
     cd /path/to/edx-analytics-data-api-client
     git remote set-url origin git@github.com:edx/edx-analytics-data-api-client.git


### PR DESCRIPTION
Just a fix on the backticks typo I've introduced on the rst file.