### PR TITLE
build: Switch to Python 3.11 for running CI tests

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -27,7 +27,7 @@ jobs:
           - name: mac
             image: macos-12
         python-version:
-          - '3.8'
+          - '3.11'
       fail-fast: false
 
     steps:

--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04 # Ubuntu 20.04 "Focal Fossa"
-        python-version: [ '3.8' ]
+        python-version: [ '3.11' ]
         services: [ discovery+lms+forum ,registrar+lms, ecommerce+lms, edx_notes_api+lms, credentials+lms, xqueue, analyticsapi+insights+lms]
       fail-fast: false # some services can be flaky; let others run to completion even if one fails
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
+          - '3.11'
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Just upgrading to match our overall move to 3.11.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
