### PR TITLE
docs: update Python 3.11 docs and more

### DIFF
--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -7,9 +7,11 @@ on:
     branches: [master]
     paths-ignore:
       - '**.rst'
+      - 'docs/'
   pull_request:
     paths-ignore:
       - '**.rst'
+      - 'docs/'
   schedule:
     # run at 7:30 am M-F
     - cron: '30 11 * * 1-5'
@@ -108,6 +110,3 @@ jobs:
            to: devstack-provisioning-tests@2u-internal.opsgenie.net
            from: github-actions <github-actions@edx.org>
            body: Devstack provisioning tests in ${{github.repository}} are back to normal for ${{matrix.services}}
-
-      - name: docs
-        run:  make docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,7 +165,7 @@ html_theme = 'sphinx_book_theme'
 # documentation.
 #
 html_theme_options = {
-    "repository_url": "https://github.com/openedx/devstack",
+    "repository_url": "https://github.com/edx/devstack",
     "repository_branch": "master",
     "path_to_docs": "docs/",
     "home_page_in_toc": True,

--- a/docs/manual_upgrades.rst
+++ b/docs/manual_upgrades.rst
@@ -7,6 +7,16 @@ Please add new instructions to the top, include a date, and make a post in the `
 
 (If you just need to update your devstack to the latest version of everything, see :doc:`updating_devstack`.)
 
+2024-06-13 - Upgrade from Python 3.8 to 3.11
+********************************************
+
+As part of the Python upgrade in edx-platform, some manual steps are required for the Python 3.11 upgrade to allow you to pull Python dependencies.
+
+1. Take latest ``git pull`` of ``devstack``
+
+2. Take the latest pull of images::
+
+    make dev.pull.without-deps.lms+cms
 
 2024-04-29 - Moved Open edX analytics repositories
 **************************************************

--- a/docs/troubleshoot_general_tips.rst
+++ b/docs/troubleshoot_general_tips.rst
@@ -224,6 +224,8 @@ To fix this locally, simply add a new subsection and publish. The act of publish
 
 See https://github.com/openedx/devstack/issues/1073 for the GitHub issue tracking this bug.
 
+Update as of 2023-08-03: The issue was moved to https://2u-internal.atlassian.net/browse/TNL-11478, but closed as "Won't Do" due to business priorities.
+
 CORS error from login_refresh in MFE
 ------------------------------------
 If you see "Access to XMLHttpRequest at 'http://localhost:18000/login_refresh' from origin 'http://localhost:2000' has been blocked by CORS policy: Request header field x-xsrf-token is not allowed by Access-Control-Allow-Headers in preflight response" it usually means you don't have a valid session.

--- a/docs/troubleshoot_general_tips.rst
+++ b/docs/troubleshoot_general_tips.rst
@@ -169,11 +169,23 @@ commands from within the repository::
 General git troubleshooting
 ---------------------------
 
-``git`` is powerful but complex; you may occasionally find your respository in a
+``git`` is powerful but complex; you may occasionally find your repository in a
 confusing state. This problem isn't devstack-specific.
 
-If you find yourself stuck, folks in the edX-internal or Open edX Slack workspaces may
-be able to give you a hand.
+If you find yourself stuck, folks in the 2U Slack workspace may be able to give
+you a hand.
+
+Ensure you are not still pointing to the old openedx repo. If you see openedx when running the following command::
+
+    % git remote -v
+    origin	ssh://git@github.com/openedx/devstack (fetch)
+    origin	ssh://git@github.com/openedx/devstack (push)
+
+You can point to the 2U fork of devstack with the following command::
+
+    % git remote set-url origin ssh://git@github.com/edx/devstack
+
+Note: You don't need to use ``ssh`` if you were using ``https` instead.
 
 Alternatively, if you are at a roadblock and
 *don't care about any changes you've made to your local copy of the repository*
@@ -181,12 +193,13 @@ Alternatively, if you are at a roadblock and
 then you can always delete the repository and start over again::
 
     rm -rf ./<repository>
-    git clone git@github.com:openedx/<repository>
+    git clone git@github.com:edx/<repository>
 
 Finally, if you regularly find yourself mystified by git, consider reading
 through `Understanding Git Conceptually`_. It explains core Git principles in way
 that makes it easier to use the simpler ``git`` commands more effectively
 and easier to use the more complicated ``git`` commands when you have to.
+
 
 Problems with shared directories
 --------------------------------

--- a/docs/troubleshoot_general_tips.rst
+++ b/docs/troubleshoot_general_tips.rst
@@ -185,7 +185,7 @@ You can point to the 2U fork of devstack with the following command::
 
     % git remote set-url origin ssh://git@github.com/edx/devstack
 
-Note: You don't need to use ``ssh`` if you were using ``https` instead.
+Note: You don't need to use ``ssh`` if you were using ``https`` instead.
 
 Alternatively, if you are at a roadblock and
 *don't care about any changes you've made to your local copy of the repository*


### PR DESCRIPTION
A variety of devstack doc updates, including:
- docs: manual upgrade for Python 3.11 
- docs: add note for Demo course is empty in studio
- fix: update readthedocs repo url
- fix: git openedx to edx repo docs

See https://github.com/edx/edx-arch-experiments/issues/578 for future work related to updating our docs.

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)