### PR TITLE
feat: Remove deprecated `version` field from docker-compose files

### DIFF
--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -1,6 +1,3 @@
-
-version: "2.1"
-
 services:
   credentials:
     volumes:

--- a/docker-compose-themes.yml
+++ b/docker-compose-themes.yml
@@ -1,5 +1,3 @@
-version: "2.1"
-
 services:
   discovery:
       volumes:

--- a/docker-compose-watchers.yml
+++ b/docker-compose-watchers.yml
@@ -1,5 +1,3 @@
-version: "2.1"
-
 services:
   lms_watcher:
     command: bash -c 'cd /edx/app/edxapp/edx-platform && source ../edxapp_env && while true; do paver watch_assets --w=$$ASSET_WATCHER_TIMEOUT; sleep 2; done'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@
 # - Every service's container name should be prefixed with "edx.devstack." to avoid conflicts with other containers
 #   that might be running for the same service.
 
-version: "2.1"
-
 services:
 
   # ================================================


### PR DESCRIPTION
This was causing docker-compose to print warnings on every operation:

```
WARN[0000] /home/timmc/edx-repos/devstack/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] /home/timmc/edx-repos/devstack/docker-compose-host.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] /home/timmc/edx-repos/devstack/docker-compose-themes.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] /home/timmc/edx-repos/devstack/docker-compose-watchers.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```

https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-top-level-element-obsolete

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
