### PR TITLE
fix: update cli-tests to use macos-latest

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -25,7 +25,7 @@ jobs:
           - name: linux
             image: ubuntu-20.04 # Focal Fossa
           - name: mac
-            image: macos-12
+            image: macos-latest
         python-version:
           - '3.11'
       fail-fast: false

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -25,7 +25,7 @@ jobs:
           - name: linux
             image: ubuntu-20.04 # Focal Fossa
           - name: mac
-            image: macos-latest
+            image: macos-14
         python-version:
           - '3.11'
       fail-fast: false

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -25,7 +25,7 @@ jobs:
           - name: linux
             image: ubuntu-20.04 # Focal Fossa
           - name: mac
-            image: macos-14
+            image: macos-13
         python-version:
           - '3.11'
       fail-fast: false


### PR DESCRIPTION
Jobs using the macos-12 YAML workflow label should be updated to macos-15, macos-14, macos-13, or macos-latest.

This is in response to the notification:
- GitHub Actions: The macOS 12 runner image will be removed by 12/3/2024

Trying `macos-13`, because 14+ failed with the following:
```
551.31 MiB / 551.31 MiB (100.00%) 50.61 MiB/stime="2024-10-16T19:28:29Z" level=info msg="Downloaded the image from \"[https://cloud-images.ubuntu.com/releases/24.04/release-20240821/ubuntu-24.04-server-cloudimg-arm64.img\](https://cloud-images.ubuntu.com/releases/24.04/release-20240821/ubuntu-24.04-server-cloudimg-arm64.img/)""
time="2024-10-16T19:28:30Z" level=info msg="[hostagent] hostagent socket created at /Users/runner/.lima/default/ha.sock"
time="2024-10-16T19:28:30Z" level=info msg="[hostagent] Using system firmware (\"/opt/homebrew/share/qemu/edk2-aarch64-code.fd\")"
time="2024-10-16T19:28:30Z" level=info msg="[hostagent] Starting QEMU (hint: to watch the boot progress, see \"/Users/runner/.lima/default/serial*.log\")"
time="2024-10-16T19:28:30Z" level=info msg="SSH Local Port: 60022"
time="2024-10-16T19:28:30Z" level=info msg="[hostagent] Waiting for the essential requirement 1 of 4: \"ssh\""
time="2024-10-16T19:28:30Z" level=info msg="[hostagent] Driver stopped due to error: \"signal: abort trap\""
time="2024-10-16T19:28:30Z" level=info msg="[hostagent] Shutting down the host agent"
time="2024-10-16T19:28:30Z" level=warning msg="[hostagent] failed to exit SSH master" error="failed to execute `ssh -O exit -p 60022 127.0.0.1`, out=\"Control socket connect(/Users/runner/.lima/default/ssh.sock): No such file or directory\\r\\n\": exit status 255"
time="2024-10-16T19:28:30Z" level=info msg="[hostagent] Shutting down QEMU with ACPI"
time="2024-10-16T19:28:30Z" level=warning msg="[hostagent] failed to open the QMP socket \"/Users/runner/.lima/default/qmp.sock\", forcibly killing QEMU" error="dial unix /Users/runner/.lima/default/qmp.sock: connect: connection refused"
time="2024-10-16T19:28:30Z" level=info msg="[hostagent] QEMU has already exited"
time="2024-10-16T19:28:30Z" level=fatal msg="exiting, status={Running:false Degraded:false Exiting:true Errors:[] SSHLocalPort:0} (hint: see \"/Users/runner/.lima/default/ha.stderr.log\")"
```

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
