### PR TITLE
Retire macos-12 in github actions

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -25,7 +25,7 @@ jobs:
           - name: linux
             image: ubuntu-20.04 # Focal Fossa
           - name: mac
-            image: macos-12
+            image: macos-13
         python-version:
           - '3.11'
       fail-fast: false
@@ -54,11 +54,11 @@ jobs:
       - name: Docker installation - Mac
         if: ${{ matrix.os.name == 'mac' }}
         run: |
-          brew install lima docker docker-compose
-          limactl start --name=default template://docker
-          echo "DOCKER_HOST=unix:///Users/runner/.lima/default/sock/docker.sock" >> $GITHUB_ENV
+          brew install colima docker docker-compose
+          colima start -a vz -m 8 -r docker
+          echo "DOCKER_HOST=unix://${HOME}/.colima/docker.sock" >> $GITHUB_ENV
           mkdir -p ~/.docker/cli-plugins
-          ln -sfn /usr/local/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
+          ln -sfn /usr/local/bin/docker-compose ~/.docker/cli-plugins/docker-compose
 
       - name: Install Python dependencies
         run:  make requirements


### PR DESCRIPTION
## Description
- PR created under the issue https://github.com/edx/edx-arch-experiments/issues/831
- Upgraded macOS version from 12 to 13.
- Replaced Lima with Colima as the Docker VM environment.

Upgrading to macOS 14 or later results in the following issue:
`time="2024-10-25T06:44:05Z" level=fatal msg="error starting vm: error at 'creating and starting': exit status 1"`