### PR TITLE
fix: Write webpack stats file to right place (so static assets can load)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -443,11 +443,14 @@ $(foreach asset_service,$(ASSET_SERVICES_LIST),\
 
 dev.static: | $(_asset_compilation_targets)
 
+# Put webpack-stats.json in the right place during NPM build:
+EDXAPP_STATIC_ROOT_ENV=STATIC_ROOT_LMS=/edx/var/edxapp/staticfiles STATIC_ROOT_CMS=/edx/var/edxapp/staticfiles/studio
+
 dev.static.lms:
-	docker compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && npm run build && ./manage.py lms collectstatic --noinput'
+	docker compose exec -T lms bash -c "source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && $(EDXAPP_STATIC_ROOT_ENV) npm run build-dev && ./manage.py lms collectstatic --no-input --settings devstack_docker"
 
 dev.static.cms:
-	docker compose exec -T cms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && npm run build && ./manage.py cms collectstatic --no-input'
+	docker compose exec -T cms bash -c "source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && $(EDXAPP_STATIC_ROOT_ENV) npm run build-dev && ./manage.py cms collectstatic --no-input --settings devstack_docker"
 
 dev.static.%: ## Rebuild static assets for the specified service's container.
 	docker compose exec -T $* bash -c 'source /edx/app/$*/$*_env && cd /edx/app/$*/$*/ && make static'

--- a/docs/troubleshoot_general_tips.rst
+++ b/docs/troubleshoot_general_tips.rst
@@ -276,6 +276,19 @@ Past problems (fixed)
 
 If you see any of the following issues, you'll need to `update your repos and pull the latest images <updating devstack_>`_.
 
+webpack-stats.json not found
+----------------------------
+
+In a devstack provisioned after May 2024, loading any page in LMS would fail with::
+
+   OSError at /
+
+   Error reading /edx/var/edxapp/staticfiles/webpack-stats.json. Are you sure webpack has generated the file and the path is correct?
+
+CMS would give the same error, but with path ``/edx/var/edxapp/staticfiles/studio/webpack-stats.json``. Static asset generation also took overly long and consumed more CPU than necessary.
+
+This was resolved in `<https://github.com/edx/devstack/pull/66>`__ in November 2024 with an adjustment to the Makefile. Updating to a more recent devstack and re-running ``make lms-static cms-static`` should fix this, but as a quick workaround, the webpack-stats.json files can be manually moved from ``/edx/app/edxapp/edx-platform/test_root/staticfiles/{studio/,}webpack-stats.json`` to ``/edx/var/edxapp/staticfiles/{studio/,}webpack-stats.json``.
+
 Permission denied for copying studio-frontend JS & CSS during provisioning
 --------------------------------------------------------------------------
 

--- a/provision-lms.sh
+++ b/provision-lms.sh
@@ -79,7 +79,7 @@ done
 
 # Create static assets for both LMS and CMS
 for app in "${apps[@]}"; do
-    docker compose exec -T  $app bash -e -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && npm run build && ./manage.py lms collectstatic --noinput --settings devstack_docker && ./manage.py cms collectstatic --noinput --settings devstack_docker'
+    make "dev.static.$app"
 done
 
 # Allow LMS SSO for CMS


### PR DESCRIPTION
After the removal of paver, static assets build wasn't completing properly in edxapp -- static files were written to the correct directory in the assets volume (mounted under /edx/var) but the webpack-stats.json files were written to the test_root dir in the app container (under /edx/app). The service would fail on first page load as it failed to find the stats file, which is apparently used for locating resources.

The static assets build was also taking quite a long time and a lot of CPU, which is likely because we were doing the production-style build with full optimization.

- Set static-root environment variables so that webpack-stats.json is written to the right place. See `staticRootLms` and `staticRootCms` in `webpack.common.config.js` in edx-platform for where that default is set. Set both LMS/CMS vars for both lms and cms since there's some dependency of CMS on LMS in the logic (and both calls build both sets of files, for better or worse).
- Use npm dev build for reduced optimization (faster build).
- Use `--settings devstack_docker` in the Makefile call to collectstatic; I'm not actually sure what the impact of that is, but it's what was in the provisioning script's version of the call and I needed to deduplicate these calls.
- Have `provision-lms.sh` just call the Makefile so that there aren't two sources of truth on how to build static assets for edxapp.

Also:

- Use same spelling of `--no-input` for both calls (either works, just make it uniform)

Addresses https://github.com/edx/devstack/issues/65

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
