### PR TITLE
fix: Use correct container name for cms-worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -643,7 +643,7 @@ services:
 
   cms-worker:
     command: bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && celery --app=cms.celery:APP worker -l debug -c 2'
-    container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.lms-worker"
+    container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.cms-worker"
     hostname: cms-worker.devstack.edx
     depends_on:
       - mysql80


### PR DESCRIPTION
Something I missed in 05b4af40bc.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
