### PR TITLE
feat: provision retirement states during lms setup

### DIFF
--- a/provision-lms.sh
+++ b/provision-lms.sh
@@ -88,5 +88,8 @@ done
 # Provision a retirement service account user
 ./provision-retirement-user.sh retirement retirement_service_worker
 
+# Provision the default retirement states
+./provision-retirement-states.sh
+
 # Add demo program
 ./programs/provision.sh lms

--- a/provision-retirement-states.sh
+++ b/provision-retirement-states.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#This script depends on the LMS being up!
+set -eu -o pipefail
+
+. scripts/colors.sh
+set -x
+
+echo -e "${GREEN}Creating retirement states...${NC}"
+docker compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker populate_retirement_states'


### PR DESCRIPTION
We would like new devstack instances to better support the user retirement pipeline out of the box after provisioning.

This PR adds a new provisioning script that will be run during LMS setup. It runs the `populate_retirement_states` management command in order to build the `user_api_retirementstate` table. Without this, user deletion will fail, as the system doesn't understand what to do when retiring user accounts.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
