### PR TITLE
feat: Add codejail service

### DIFF
--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -61,6 +61,11 @@ services:
   cms-worker:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform
+  codejail:
+    volumes:
+      - ${DEVSTACK_WORKSPACE}/codejail-service:/app
+      - ${DEVSTACK_WORKSPACE}/src:/edx/src
+      - ${PWD}/py_configuration_files/codejail.py:/app/codejail_service/settings/devstack.py
   insights:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-analytics-dashboard:/edx/app/insights/insights

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -657,6 +657,17 @@ services:
       # Dangerous to run Celery as root normally, but it's how we do things in devstack for some reason
       C_FORCE_ROOT: "true"
 
+  codejail:
+    container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.codejail"
+    hostname: codejail.devstack.edx
+    stdin_open: true
+    tty: true
+    image: edxops/codejail-dev:latest
+    environment:
+      DJANGO_SETTINGS_MODULE: codejail_service.settings.devstack
+    ports:
+      - "18030:8080"
+
   xqueue:
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.xqueue"
     image: edxops/xqueue-dev:latest

--- a/docs/service_list.rst
+++ b/docs/service_list.rst
@@ -41,6 +41,8 @@ Instead of a service name or list, you can also run commands like ``make dev.pro
 +------------------------------------+-------------------------------------+----------------+--------------+
 | `frontend-app-authn`_              | http://localhost:1999/              | MFE (React.js) | Default      |
 +------------------------------------+-------------------------------------+----------------+--------------+
+| `codejail`_                        | http://localhost:18030/             | Python/Django  | Extra        |
++------------------------------------+-------------------------------------+----------------+--------------+
 | `registrar`_                       | http://localhost:18734/api-docs/    | Python/Django  | Extra        |
 +------------------------------------+-------------------------------------+----------------+--------------+
 | `frontend-app-program-console`_    | http://localhost:1976/              | MFE (React.js) | Extra        |
@@ -84,6 +86,7 @@ Some common service combinations include:
 .. _frontend-app-gradebook: https://github.com/openedx/frontend-app-gradebook
 .. _lms: https://github.com/openedx/edx-platform
 .. _frontend-app-program-console: https://github.com/edx/frontend-app-program-console
+.. _codejail: https://github.com/openedx/codejail-service
 .. _registrar: https://github.com/edx/registrar
 .. _cms: https://github.com/openedx/edx-platform
 .. _frontend-app-learner-dashboard: https://github.com/openedx/frontend-app-learner-dashboard

--- a/options.mk
+++ b/options.mk
@@ -67,7 +67,7 @@ credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-authn+frontend-
 # Separated by plus signs.
 # Separated by plus signs. Listed in alphabetical order for clarity.
 EDX_SERVICES ?= \
-analyticsapi+credentials+cms+cms-worker+cms_watcher+discovery+ecommerce+edx_notes_api+forum+frontend-app-account+frontend-app-learner-dashboard+frontend-app-learner-record+frontend-app-profile+frontend-app-authn+frontend-app-course-authoring+frontend-app-gradebook+frontend-app-ora-grading+frontend-app-learning+frontend-app-library-authoring+frontend-app-payment+frontend-app-program-console+frontend-app-publisher+insights+lms+lms-worker+lms_watcher+registrar+registrar-worker+xqueue+xqueue_consumer+enterprise-catalog+license-manager
+analyticsapi+codejail+credentials+cms+cms-worker+cms_watcher+discovery+ecommerce+edx_notes_api+forum+frontend-app-account+frontend-app-learner-dashboard+frontend-app-learner-record+frontend-app-profile+frontend-app-authn+frontend-app-course-authoring+frontend-app-gradebook+frontend-app-ora-grading+frontend-app-learning+frontend-app-library-authoring+frontend-app-payment+frontend-app-program-console+frontend-app-publisher+insights+lms+lms-worker+lms_watcher+registrar+registrar-worker+xqueue+xqueue_consumer+enterprise-catalog+license-manager
 
 # Services with database migrations.
 # Should be a subset of $(EDX_SERVICES).

--- a/py_configuration_files/codejail.py
+++ b/py_configuration_files/codejail.py
@@ -1,0 +1,3 @@
+"""Settings for devstack use."""
+
+from codejail_service.settings.local import *  # pylint: disable=wildcard-import

--- a/repo.sh
+++ b/repo.sh
@@ -38,6 +38,7 @@ repos=(
     "https://github.com/edx/edx-analytics-data-api.git"
     "https://github.com/openedx/enterprise-catalog.git"
     "https://github.com/openedx/license-manager.git"
+    "https://github.com/openedx/codejail-service.git"
 )
 
 non_release_repos=(
@@ -70,6 +71,7 @@ ssh_repos=(
     "git@github.com:edx/edx-analytics-dashboard.git"
     "git@github.com:edx/edx-analytics-data-api.git"
     "git@github.com:openedx/license-manager.git"
+    "git@github.com:openedx/codejail-service.git"
 )
 
 non_release_ssh_repos=(


### PR DESCRIPTION
The image specified here is not yet available, but should be the right name for after <https://github.com/edx/public-dockerfiles/pull/85> merges. I've tested with a local tag.

The codejail-service repo will be pulled by default but will not be a dependency of lms/cms (yet?).

This is part of https://github.com/edx/edx-arch-experiments/issues/894

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
