### PR TITLE
feat: Make live-reloading explicit for codejail

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -658,6 +658,7 @@ services:
       C_FORCE_ROOT: "true"
 
   codejail:
+    command: bash -c 'source /venv/bin/activate; while true; do python ./manage.py runserver 0.0.0.0:8080; sleep 2; done'
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.codejail"
     hostname: codejail.devstack.edx
     stdin_open: true


### PR DESCRIPTION
This goes with https://github.com/edx/public-dockerfiles/pull/92 which switches the default CMD from runserver to gunicorn; we want to keep runserver.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
