### PR TITLE
docs: update theming config example

### DIFF
--- a/docs/devstack_faq.rst
+++ b/docs/devstack_faq.rst
@@ -127,7 +127,7 @@ Make sure that you enable the following code in ./edx-platform/lms/envs/devstack
        "/edx/app/edxapp/edx-platform/themes/",
        "/edx/app/edx-themes/edx-platform/",
    ]
-   TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
+   TEMPLATES[1]["DIRS"] = Derived(_make_mako_template_dirs)
    derive_settings(__name__)
 
 Enabling a theme

--- a/py_configuration_files/lms.py
+++ b/py_configuration_files/lms.py
@@ -480,7 +480,7 @@ DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL = True
 # COMPREHENSIVE_THEME_DIRS = [
 #     "/edx/app/edxapp/edx-platform/themes/"
 # ]
-# TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
+# TEMPLATES[1]["DIRS"] = Derived(_make_mako_template_dirs)
 # derive_settings(__name__)
 
 # Uncomment the lines below if you'd like to see SQL statements in your devstack LMS log.


### PR DESCRIPTION
Updates theming config example in our docs after recent changes to edx-platform (see https://github.com/openedx/edx-platform/pull/36192).

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
