### PR TITLE
chore: adding the link to the profile MFE

### DIFF
--- a/py_configuration_files/lms.py
+++ b/py_configuration_files/lms.py
@@ -384,6 +384,7 @@ EDXNOTES_CLIENT_NAME = 'edx_notes_api-backend-service'
 ############## Settings for Microfrontends  #########################
 LEARNING_MICROFRONTEND_URL = 'http://localhost:2000'
 ACCOUNT_MICROFRONTEND_URL = 'http://localhost:1997'
+PROFILE_MICROFRONTEND_URL = 'http://localhost:1995'
 COMMUNICATIONS_MICROFRONTEND_URL = 'http://localhost:1984'
 AUTHN_MICROFRONTEND_URL = 'http://localhost:1999'
 AUTHN_MICROFRONTEND_DOMAIN = 'localhost:1999'


### PR DESCRIPTION
Adding the link to the profile mfe  to the base configuration because the legacy pages are gone and will no longer redirect.

FIXES: APER-3884

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
