### PR TITLE
feat: AppArmor confinement for codejail-service

### DIFF
--- a/codejail.profile
+++ b/codejail.profile
@@ -40,13 +40,18 @@ profile codejail_service flags=(mediate_deleted) {
     # Filesystem access -- self-explanatory
     file,
 
-    # `network` is required for sudo
-    # TODO: Restrict this so that general network access is not permitted
-    network,
+    # netlink is needed for sudo's interprocess communication
+    network netlink raw,
 
-    # Various capabilities required for sudoing to sandbox (setuid,
-    # setgid, audit_write) and for sending a kill signal (kill).
-    capability setuid setgid audit_write kill,
+    # Allow all of the various network operations required to listen, accept connection, etc.
+    network tcp,
+    # But then deny making a new *outbound* connection.
+    deny network (connect) tcp,
+
+    # Required for sudoing to sandbox
+    capability setuid setgid audit_write,
+    # Allow sending a kill signal
+    capability kill,
 
     # Allow sending a kill signal to the sandbox when the execution
     # runs beyond time limits.

--- a/codejail.profile
+++ b/codejail.profile
@@ -55,6 +55,8 @@ profile codejail_service flags=(mediate_deleted) {
     # The core of the confinement: When the sandbox Python is executed, switch to
     # the (extremely constrained) child profile.
     #
+    # This path needs to be coordinated with the Dockerfile and Django settings.
+    #
     # Manpage: "Cx: transition to subprofile on execute -- scrub the environment"
     /sandbox/venv/bin/python Cx -> child,
 

--- a/codejail.profile
+++ b/codejail.profile
@@ -88,6 +88,9 @@ profile codejail_service flags=(mediate_deleted) {
         # includes the sandbox's copy of Python as well as any
         # dependencies that have been installed for inclusion in
         # sandboxes.
+        #
+        # m: executable mapping, required for shared libraries used by some
+        #    Python dependencies with C compontents, eg `nltk`.
         /sandbox/venv/** rm,
 
         # Allow access to the temporary directories that are set up by

--- a/codejail.profile
+++ b/codejail.profile
@@ -30,9 +30,9 @@ include <tunables/global>
 abi <abi/3.0>,
 
 # This outer profile applies to the entire container, and isn't as
-# important. If the sandbox profile doesn't work, it's not likely that
+# important. If the inner profile doesn't work, it's not likely that
 # the outer one is going to help. But there may be some small value in
-# defense-in-depth, as it's possible that a bug in the child (sandbox)
+# defense-in-depth, as it's possible that a bug in the codejail_sandbox (inner)
 # profile isn't present in the outer one.
 profile codejail_service flags=(mediate_deleted) {
 
@@ -58,17 +58,17 @@ profile codejail_service flags=(mediate_deleted) {
     # Allow sending a kill signal
     capability kill,
 
-    # Allow sending a kill signal to the child subprofile when the execution
+    # Allow sending a kill signal to the codejail_sandbox subprofile when the execution
     # runs beyond time limits.
-    signal (send) set=(kill) peer=codejail_service//child,
+    signal (send) set=(kill) peer=codejail_service//codejail_sandbox,
 
     # The core of the confinement: When the sandbox Python is executed, switch to
-    # the (extremely constrained) child profile.
+    # the (extremely constrained) codejail_sandbox profile.
     #
     # This path needs to be coordinated with the Dockerfile and Django settings.
     #
     # Manpage: "Cx: transition to subprofile on execute -- scrub the environment"
-    /sandbox/venv/bin/python Cx -> child,
+    /sandbox/venv/bin/python Cx -> codejail_sandbox,
 
     # This is the important apparmor profile -- the one that actually
     # constrains the sandbox Python process.
@@ -77,7 +77,7 @@ profile codejail_service flags=(mediate_deleted) {
     # apparmor will continue to make policy decisions in cases where a confined
     # executable has a handle to a file's inode even after the file is removed
     # from the filesystem.
-    profile child flags=(mediate_deleted) {
+    profile codejail_sandbox flags=(mediate_deleted) {
 
         # This inner profile also gets general access to "safe"
         # actions; we could list those explicitly out of caution but

--- a/codejail.profile
+++ b/codejail.profile
@@ -30,7 +30,7 @@ include <tunables/global>
 abi <abi/3.0>,
 
 # This outer profile applies to the entire container, and isn't as
-# important. If the inner profile doesn't work, it's not likely that
+# important as the inner (codejail_sandbox) profile. If the inner profile doesn't work, it's not likely that
 # the outer one is going to help. But there may be some small value in
 # defense-in-depth, as it's possible that a bug in the codejail_sandbox (inner)
 # profile isn't present in the outer one.

--- a/codejail.profile
+++ b/codejail.profile
@@ -1,0 +1,75 @@
+# AppArmor profile for running codejail-service in devstack.
+#
+#                         #=========#
+#                         # WARNING #
+#                         #=========#
+#
+# This is not a complete and secure apparmor profile! Do not use this
+# in any deployed environment (even a staging environment) without
+# careful inspection and modification to fit your needs.
+#
+# Failure to apply a secure apparmor profile *will* likely result in a
+# compromise of your environment by an attacker.
+#
+# We may at some point make this file good enough for confinement in
+# production, but for now it is only intended to be used in devstack.
+
+
+#include <tunables/global>
+
+# Declare ABI version explicitly to ensure that confinement is
+# actually applied appropriately on newer Ubuntu.
+abi <abi/3.0>,
+
+# This outer profile applies to the entire container, and isn't as
+# important. If the sandbox profile doesn't work, it's not likely that
+# the outer one is going to help. But there may be some small value in
+# defense-in-depth, as it's possible that a bug in the child (sandbox)
+# profile isn't present in the outer one.
+profile codejail_service flags=(attach_disconnected,mediate_deleted) {
+    #include <abstractions/base>
+
+    # Filesystem access -- self-explanatory
+    file,
+
+    # `network` is required for sudo
+    # TODO: Restrict this so that general network access is not permitted
+    network,
+
+    # Various capabilities required for sudoing to sandbox (setuid,
+    # setgid, audit_write) and for sending a kill signal (kill).
+    capability setuid setgid audit_write kill,
+
+    # Allow sending a kill signal to the sandbox when the execution
+    # runs beyond time limits.
+    signal (send) set=(kill) peer=codejail_service//child,
+
+    # Allow executing this binary, but force a transition to the specified
+    # profile (and scrub the environment).
+    /sandbox/venv/bin/python Cx -> child,
+
+    # This is the important apparmor profile -- the one that actually
+    # constrains the sandbox Python process.
+    profile child flags=(attach_disconnected,mediate_deleted) {
+        #include <abstractions/base>
+
+        # Read and run binaries and libraries in the virtualenv. This
+        # includes the sandbox's copy of Python as well as any
+        # dependencies that have been installed for inclusion in
+        # sandboxes.
+        /sandbox/venv/** rm,
+
+        # Codejail has a hardcoded reference to this file path, although the
+        # use of /tmp specifically may be controllable with environment variables:
+        # https://github.com/openedx/codejail/blob/0165d9ca351/codejail/util.py#L15
+        /tmp/codejail-*/ r,
+        /tmp/codejail-*/** rw,
+
+        # Allow interactive terminal during development
+        /dev/pts/* rw,
+
+        # Allow receiving a kill signal from the webapp when the execution
+        # runs beyond time limits.
+        signal (receive) set=(kill) peer=codejail_service,
+    }
+}

--- a/codejail.profile
+++ b/codejail.profile
@@ -18,8 +18,10 @@
 # by OS, see /etc/apparmor.d/tunables/global for contents.
 include <tunables/global>
 
-# Declare ABI version explicitly to ensure that confinement is
-# actually applied appropriately on newer Ubuntu.
+# Require that the system understands the feature set that this policy was written
+# for. If we didn't include this, then on Ubuntu >= 22.04, AppArmor might assume
+# the wrong feature set was requested, and some rules might become too permissive.
+# See https://github.com/netblue30/firejail/issues/3659#issuecomment-711074899
 abi <abi/3.0>,
 
 # This outer profile applies to the entire container, and isn't as

--- a/codejail.profile
+++ b/codejail.profile
@@ -14,8 +14,9 @@
 # We may at some point make this file good enough for confinement in
 # production, but for now it is only intended to be used in devstack.
 
-
-#include <tunables/global>
+# Sets standard variables used by abstractions/base, later. Controlled
+# by OS, see /etc/apparmor.d/tunables/global for contents.
+include <tunables/global>
 
 # Declare ABI version explicitly to ensure that confinement is
 # actually applied appropriately on newer Ubuntu.
@@ -27,7 +28,12 @@ abi <abi/3.0>,
 # defense-in-depth, as it's possible that a bug in the child (sandbox)
 # profile isn't present in the outer one.
 profile codejail_service flags=(attach_disconnected,mediate_deleted) {
-    #include <abstractions/base>
+
+    # Allow access to a variety of commonly needed, generally safe things
+    # (such as reading /dev/random, free memory, etc.)
+    #
+    # Manpage: "Includes files that should be readable and writable in all profiles."
+    include <abstractions/base>
 
     # Filesystem access -- self-explanatory
     file,
@@ -51,7 +57,11 @@ profile codejail_service flags=(attach_disconnected,mediate_deleted) {
     # This is the important apparmor profile -- the one that actually
     # constrains the sandbox Python process.
     profile child flags=(attach_disconnected,mediate_deleted) {
-        #include <abstractions/base>
+
+        # This inner profile also gets general access to "safe"
+        # actions; we could list those explicitly out of caution but
+        # it could get pretty verbose.
+        include <abstractions/base>
 
         # Read and run binaries and libraries in the virtualenv. This
         # includes the sandbox's copy of Python as well as any

--- a/codejail.profile
+++ b/codejail.profile
@@ -8,11 +8,16 @@
 # in any deployed environment (even a staging environment) without
 # careful inspection and modification to fit your needs.
 #
+# See https://manpages.ubuntu.com/manpages/noble/man5/apparmor.d.5.html
+# or `man apparmor.d` for documentation of syntax and options.
+#
 # Failure to apply a secure apparmor profile *will* likely result in a
 # compromise of your environment by an attacker.
 #
 # We may at some point make this file good enough for confinement in
 # production, but for now it is only intended to be used in devstack.
+
+
 
 # Sets standard variables used by abstractions/base, later. Controlled
 # by OS, see /etc/apparmor.d/tunables/global for contents.

--- a/codejail.profile
+++ b/codejail.profile
@@ -53,7 +53,7 @@ profile codejail_service flags=(mediate_deleted) {
     # Allow sending a kill signal
     capability kill,
 
-    # Allow sending a kill signal to the sandbox when the execution
+    # Allow sending a kill signal to the child subprofile when the execution
     # runs beyond time limits.
     signal (send) set=(kill) peer=codejail_service//child,
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -726,11 +726,13 @@ services:
     hostname: codejail.devstack.edx
     stdin_open: true
     tty: true
-    image: edxops/codejail-dev:latest
+    image: edxops/codejail-service-dev:latest
     environment:
       DJANGO_SETTINGS_MODULE: codejail_service.settings.devstack
     ports:
       - "18030:8080"
+    security_opt:
+      - apparmor=codejail_service
 
   xqueue:
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.xqueue"

--- a/docs/codejail.rst
+++ b/docs/codejail.rst
@@ -19,7 +19,7 @@ In order to run the codejail devstack component:
 
 1. Install AppArmor: ``sudo apt install apparmor``
 2. Add the codejail AppArmor profile to your OS, or update it: ``sudo apparmor_parser --replace -W codejail.profile``
-3. Configure LMS and CMS to use the codejail-service by changing ``ENABLE_CODEJAIL_REST_SERVICE`` to ``True`` in ``py_configuration_files/{lms,cms}.py``
+3. Configure LMS and CMS to use the codejail-service by uncommenting ``# ENABLE_CODEJAIL_REST_SERVICE = True`` in ``py_configuration_files/{lms,cms}.py``
 4. Run ``make codejail-up``
 
 The service does not need any provisioning, and does not have dependencies.

--- a/docs/codejail.rst
+++ b/docs/codejail.rst
@@ -6,11 +6,9 @@ The ``codejail`` devstack component (codejail-service) requires some additional 
 Background
 **********
 
-Both LMS and CMS can run Python code submitted by instructors and learners in order to implement custom Python-graded problems. By default this involves running the code on the same host as edxapp itself. Ordinarily this would be quite dangerous, but we use a sandboxing library called `codejail <https://github.com/openedx/codejail>`__ in order to confine the code execution in terms of disk and network access as well as memory, CPU, and other resource limits. Part of these restrictions are implemented via AppArmor, a utility available in some Linux distributions (including Debian and Ubuntu).
+The `codejail-service <https://github.com/openedx/codejail-service>`__ webapp is a wrapper around the `codejail <https://github.com/openedx/codejail>`__ library. See the READMEs of each repo for more information on the special requirements for deploying codejail, in particular the AppArmor-based sandboxing.
 
-While AppArmor provides good protection, a sandbox escape could still be possible due to misconfiguration or bugs in AppArmor. For defense in depth, we're setting up a dedicated `codejail service <https://github.com/openedx/codejail-service>`__ that will perform code execution for edxapp and which will allow further isolation.
-
-The default edxapp codejail defaults to unsafe, direct execution of Python code, and this remains true in devstack. We don't even have a way to run on-host codejail securely in devstack. In constrast, the codejail service refuses to run if codejail has not been configured properly, and we've included a way to run it in devstack.
+References to "codejail" can mean either the library or the service. In devstack, "codejail" usually refers to the service.
 
 Configuration
 *************

--- a/docs/codejail.rst
+++ b/docs/codejail.rst
@@ -13,21 +13,25 @@ References to "codejail" can mean either the library or the service. In devstack
 Configuration
 *************
 
+**TODO**: These instructions are for Linux. We need some instructions for how to do this on Mac; it probably involves accessing the Linux VM that docker is run inside of.
+
 In order to run the codejail devstack component:
 
 1. Install AppArmor: ``sudo apt install apparmor``
-2. Add the codejail AppArmor profile to your OS, or update it: ``sudo apparmor_parser --replace -W codejail.profile``
+2. Add the provided codejail AppArmor profile to your OS: ``sudo apparmor_parser --add -W ./codejail.profile``
 3. Configure LMS and CMS to use the codejail-service by uncommenting ``# ENABLE_CODEJAIL_REST_SERVICE = True`` in ``py_configuration_files/{lms,cms}.py``
 4. Run ``make codejail-up``
 
 The service does not need any provisioning, and does not have dependencies.
+
+Over time, the AppArmor profile may need to be updated. Changes to the file do not automatically cause changes to the version that has been installed in the OS. When significant changes have been made to the profile, you'll need to re-install the profile. This can be done by passing ``--replace`` instead of ``--add``, like so: ``sudo apparmor_parser --replace -W ./codejail.profile``
 
 Development
 ***********
 
 Changes to the AppArmor profile must be coordinated with changes to the Dockerfile, as they need to agree on filesystem paths.
 
-Any time you update the profile, you'll need to re-run the command to apply the profile.
+Any time you update the profile, you'll need to update the profile in your OS as well: ``sudo apparmor_parser --replace -W ./codejail.profile``
 
 The profile file contains the directive ``profile codejail_service``. That defines the name of the profile when it is installed into the kernel. In order to change that name, you must first remove the profile **under the old name**, then install a new profile under the new name. To remove a profile, use the ``--remove`` action instead of the ``-replace`` action: : ``sudo apparmor_parser --remove -W codejail.profile``
 

--- a/docs/codejail.rst
+++ b/docs/codejail.rst
@@ -31,7 +31,7 @@ Development
 
 Changes to the AppArmor profile must be coordinated with changes to the Dockerfile, as they need to agree on filesystem paths.
 
-Any time you update the profile, you'll need to update the profile in your OS as well: ``sudo apparmor_parser --replace -W ./codejail.profile``
+Any time you update the profile file, you'll need to update the profile in your OS as well: ``sudo apparmor_parser --replace -W ./codejail.profile``
 
 The profile file contains the directive ``profile codejail_service``. That defines the name of the profile when it is installed into the OS, and must agree with the relevant ``security_opt`` line in ``docker-compose.yml``. This name should not be changed, as it creates a confusing situation and would require every developer who uses codejail-service to do a number of manual steps. (Profiles can't be renamed *within* the OS; they must first be removed **under the old name**, and then a new profile must be installed under the new name.)
 

--- a/docs/codejail.rst
+++ b/docs/codejail.rst
@@ -1,0 +1,43 @@
+Codejail service
+################
+
+The ``codejail`` devstack component (codejail-service) requires some additional configuration before it can be enabled. This page describes how to set it up and debug it.
+
+Background
+**********
+
+Both LMS and CMS can run Python code submitted by instructors and learners in order to implement custom Python-graded problems. By default this involves running the code on the same host as edxapp itself. Ordinarily this would be quite dangerous, but we use a sandboxing library called `codejail <https://github.com/openedx/codejail>`__ in order to confine the code execution in terms of disk and network access as well as memory, CPU, and other resource limits. Part of these restrictions are implemented via AppArmor, a utility available in some Linux distributions (including Debian and Ubuntu).
+
+While AppArmor provides good protection, a sandbox escape could still be possible due to misconfiguration or bugs in AppArmor. For defense in depth, we're setting up a dedicated `codejail service <https://github.com/openedx/codejail-service>`__ that will perform code execution for edxapp and which will allow further isolation.
+
+The default edxapp codejail defaults to unsafe, direct execution of Python code, and this remains true in devstack. We don't even have a way to run on-host codejail securely in devstack. In constrast, the codejail service refuses to run if codejail has not been configured properly, and we've included a way to run it in devstack.
+
+Configuration
+*************
+
+In order to run the codejail devstack component:
+
+1. Install AppArmor: ``sudo apt install apparmor``
+2. Add the codejail AppArmor profile to your OS, or update it: ``sudo apparmor_parser --replace -W codejail.profile``
+3. Configure LMS and CMS to use the codejail-service by changing ``ENABLE_CODEJAIL_REST_SERVICE`` to ``True`` in ``py_configuration_files/{lms,cms}.py``
+4. Run ``make codejail-up``
+
+The service does not need any provisioning, and does not have dependencies.
+
+Development
+***********
+
+Changes to the AppArmor profile must be coordinated with changes to the Dockerfile, as they need to agree on filesystem paths.
+
+Any time you update the profile, you'll need to re-run the command to apply the profile.
+
+The profile file contains the directive ``profile codejail_service``. That defines the name of the profile when it is installed into the kernel. In order to change that name, you must first remove the profile **under the old name**, then install a new profile under the new name. To remove a profile, use the ``--remove`` action instead of the ``-replace`` action: : ``sudo apparmor_parser --remove -W codejail.profile``
+
+The profile name must also agree with the relevant ``security_opt`` line in devstack's ``docker-compose.yml``.
+
+Debugging
+*********
+
+To check whether the profile has been applied, run ``sudo aa-status | grep codejail``. This won't tell you if the profile is out of date, but it will tell you if you have *some* version of it installed.
+
+If you need to debug the confinement, either because it is restricting too much or too little, a good strategy is to run ``tail -F /var/log/kern.log | grep codejail`` and watch for ``DENIED`` lines. You should expect to see several appear during service startup, as the service is designed to probe the confinement as part of its initial healthcheck.

--- a/docs/codejail.rst
+++ b/docs/codejail.rst
@@ -13,7 +13,7 @@ References to "codejail" can mean either the library or the service. In devstack
 Configuration
 *************
 
-**TODO**: These instructions are for Linux. We need some instructions for how to do this on Mac; it probably involves accessing the Linux VM that docker is run inside of.
+These instructions are for Linux only. Additional research would be required to create instructions for a Mac, which probably involves accessing the Linux VM that docker is run inside of.
 
 In order to run the codejail devstack component:
 

--- a/docs/codejail.rst
+++ b/docs/codejail.rst
@@ -33,9 +33,7 @@ Changes to the AppArmor profile must be coordinated with changes to the Dockerfi
 
 Any time you update the profile, you'll need to update the profile in your OS as well: ``sudo apparmor_parser --replace -W ./codejail.profile``
 
-The profile file contains the directive ``profile codejail_service``. That defines the name of the profile when it is installed into the kernel. In order to change that name, you must first remove the profile **under the old name**, then install a new profile under the new name. To remove a profile, use the ``--remove`` action instead of the ``-replace`` action: : ``sudo apparmor_parser --remove -W codejail.profile``
-
-The profile name must also agree with the relevant ``security_opt`` line in devstack's ``docker-compose.yml``.
+The profile file contains the directive ``profile codejail_service``. That defines the name of the profile when it is installed into the OS, and must agree with the relevant ``security_opt`` line in ``docker-compose.yml``. This name should not be changed, as it creates a confusing situation and would require every developer who uses codejail-service to do a number of manual steps. (Profiles can't be renamed *within* the OS; they must first be removed **under the old name**, and then a new profile must be installed under the new name.)
 
 Debugging
 *********

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,3 +27,4 @@ Contents
    troubleshoot_general_tips
    manual_upgrades
    advanced_configuration
+   codejail

--- a/py_configuration_files/cms.py
+++ b/py_configuration_files/cms.py
@@ -316,7 +316,8 @@ xblock_duplicated_event_setting['course-authoring-xblock-lifecycle']['enabled'] 
 
 # Disabled by default since codejail service needs to be configured
 # and started separately. See docs/codejail.rst for details.
-ENABLE_CODEJAIL_REST_SERVICE = False
+
+# ENABLE_CODEJAIL_REST_SERVICE = True
 CODE_JAIL_REST_SERVICE_HOST = "http://edx.devstack.codejail:8080"
 
 

--- a/py_configuration_files/cms.py
+++ b/py_configuration_files/cms.py
@@ -316,8 +316,10 @@ xblock_duplicated_event_setting['course-authoring-xblock-lifecycle']['enabled'] 
 
 # Disabled by default since codejail service needs to be configured
 # and started separately. See docs/codejail.rst for details.
+#ENABLE_CODEJAIL_REST_SERVICE = True
 
-# ENABLE_CODEJAIL_REST_SERVICE = True
+# Note that this is exposed on port 8080 to other devstack services,
+# but 18030 outside of Docker.
 CODE_JAIL_REST_SERVICE_HOST = "http://edx.devstack.codejail:8080"
 
 

--- a/py_configuration_files/cms.py
+++ b/py_configuration_files/cms.py
@@ -312,6 +312,13 @@ xblock_deleted_event_setting['course-authoring-xblock-lifecycle']['enabled'] = T
 xblock_duplicated_event_setting = EVENT_BUS_PRODUCER_CONFIG['org.openedx.content_authoring.xblock.duplicated.v1']
 xblock_duplicated_event_setting['course-authoring-xblock-lifecycle']['enabled'] = True
 
+############################ Codejail ############################
+
+# Disabled by default since codejail service needs to be configured
+# and started separately. See docs/codejail.rst for details.
+ENABLE_CODEJAIL_REST_SERVICE = False
+CODE_JAIL_REST_SERVICE_HOST = "http://edx.devstack.codejail:8080"
+
 
 ################# New settings must go ABOVE this line #################
 ########################################################################

--- a/py_configuration_files/codejail.py
+++ b/py_configuration_files/codejail.py
@@ -12,7 +12,8 @@ ALLOWED_HOSTS = [
 CODEJAIL_ENABLED = True
 
 CODE_JAIL = {
-    # These values are coordinated with the Dockerfile and AppArmor profile
+    # These values are coordinated with the Dockerfile (in edx/public-dockerfiles)
+    # and the AppArmor profile (codejail.profile in edx/devstack).
     'python_bin': '/sandbox/venv/bin/python',
     'user': 'sandbox',
 

--- a/py_configuration_files/codejail.py
+++ b/py_configuration_files/codejail.py
@@ -1,3 +1,28 @@
 """Settings for devstack use."""
 
 from codejail_service.settings.local import *  # pylint: disable=wildcard-import
+
+ALLOWED_HOSTS = [
+    # When called from outside of docker's network (dev's terminal)
+    'localhost',
+    # When called from another container (lms, cms)
+    'edx.devstack.codejail',
+]
+
+CODEJAIL_ENABLED = True
+
+CODE_JAIL = {
+    # These values are coordinated with the Dockerfile and AppArmor profile
+    'python_bin': '/sandbox/venv/bin/python',
+    'user': 'sandbox',
+
+    # Configurable limits.
+    'limits': {
+        # CPU-seconds
+        'CPU': 3,
+        # 100 MiB memory
+        'VMEM': 100 * 1024 * 1024,
+        # Clock seconds
+        'REALTIME': 3,
+    },
+}

--- a/py_configuration_files/lms.py
+++ b/py_configuration_files/lms.py
@@ -558,8 +558,10 @@ CSRF_TRUSTED_ORIGINS = [
 
 # Disabled by default since codejail service needs to be configured
 # and started separately. See docs/codejail.rst for details.
+#ENABLE_CODEJAIL_REST_SERVICE = True
 
-# ENABLE_CODEJAIL_REST_SERVICE = True
+# Note that this is exposed on port 8080 to other devstack services,
+# but 18030 outside of Docker.
 CODE_JAIL_REST_SERVICE_HOST = "http://edx.devstack.codejail:8080"
 
 ################# New settings must go ABOVE this line #################

--- a/py_configuration_files/lms.py
+++ b/py_configuration_files/lms.py
@@ -554,6 +554,12 @@ CSRF_TRUSTED_ORIGINS = [
     'http://localhost:1996',  # frontend-app-learner-dashboard
 ]
 
+############################ Codejail ############################
+
+# Disabled by default since codejail service needs to be configured
+# and started separately. See docs/codejail.rst for details.
+ENABLE_CODEJAIL_REST_SERVICE = False
+CODE_JAIL_REST_SERVICE_HOST = "http://edx.devstack.codejail:8080"
 
 ################# New settings must go ABOVE this line #################
 ########################################################################

--- a/py_configuration_files/lms.py
+++ b/py_configuration_files/lms.py
@@ -558,7 +558,8 @@ CSRF_TRUSTED_ORIGINS = [
 
 # Disabled by default since codejail service needs to be configured
 # and started separately. See docs/codejail.rst for details.
-ENABLE_CODEJAIL_REST_SERVICE = False
+
+# ENABLE_CODEJAIL_REST_SERVICE = True
 CODE_JAIL_REST_SERVICE_HOST = "http://edx.devstack.codejail:8080"
 
 ################# New settings must go ABOVE this line #################


### PR DESCRIPTION
Allow codejail-service to actually run code (and run it securely) by giving it the needed confinement. Previously it would run but refuse to execute code since it would detect the insecure environment; now, the startup safety checks pass and the code-exec endpoint works as expected.

- Add an AppArmor profile with fairly strict rules. It needs to be thoroughly vetted and to have exceptions added before it can be used in production, but it's be fine for devstack. Some parts are based on the existing edxapp apparmor config without careful review.
- Apply the profile to the codejail service in docker-compose.
- Add Django configs for codejail service.
- Add documentation for installing the profile so that it is available for use on the dev's machine.

Also:

- Add configuration and documentation for edxapp to actually call the codejail service, disabled by default. (Will later want to make this default to true, once the service is working properly.)
- Update image name in docker-compose to follow rename in https://github.com/edx/public-dockerfiles/pull/102

Currently edxapp gets an error back from codejail-service, and then isn't able to read that error; separate work in the app repo will be needed to fix those. (The first issue relates to python_path, and the other to not returning globals_dict when there's an emsg.) But the integration is working otherwise.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
