### PR TITLE
chore: adding convenience script to new utility dir

### DIFF
--- a/utils/README.rst
+++ b/utils/README.rst
@@ -1,0 +1,5 @@
+Devstack
+########
+
+This directory holds convenience and utility scripts that might be useful to
+users of devstack, but have no other home in source control.

--- a/utils/README.rst
+++ b/utils/README.rst
@@ -1,5 +1,5 @@
-Devstack
-########
+utils
+#####
 
 This directory holds convenience and utility scripts that might be useful to
 users of devstack, but have no other home in source control.

--- a/utils/pull-all-repos-in-directory.sh
+++ b/utils/pull-all-repos-in-directory.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+################
+
+sync_directory() {
+  IFS=$'\n'
+
+  for REPO in `ls "$1/"`
+  do
+    if [ -d "$1/$REPO" ]
+    then
+      echo "Updating $1/$REPO at `date`"
+      if [ -d "$1/$REPO/.git" ]
+      then
+        git -C "$1/$REPO" pull
+      else
+        sync_directory "$1/$REPO"
+      fi
+      echo "Done at `date`"
+    fi
+  done
+}
+
+REPOSITORIES="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+sync_directory $REPOSITORIES
+


### PR DESCRIPTION
* creates a new directory for utilities
* adds the  currently-in-use copy of pull-all-repos-in-directory.sh that is currently only shared via the hosted devstack AMI

FIXES: APER-3925

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
