### PR TITLE
fix: fixup theming setup during devstack provisioning

### DIFF
--- a/provision-set-edx-theme.sh
+++ b/provision-set-edx-theme.sh
@@ -2,7 +2,7 @@
 
 # This script sets up the edX theme in LMS and CMS.
 
-REPO_URL="https://github.com/edx/edx-themes"
+REPO_URL="git@github.com:edx/edx-themes.git"
 THEME_DIR="/edx/src/edx-themes/edx-platform"
 DEVSTACK_FILE="../edx-platform/lms/envs/devstack.py"
 
@@ -24,7 +24,7 @@ sed -i '' "/COMPREHENSIVE_THEME_DIRS = \[/a\\
 \"$THEME_DIR\",
 " "$DEVSTACK_FILE"
 sed -i '' "s|^# \]|]|" "$DEVSTACK_FILE"
-sed -i '' "s|^# TEMPLATES\[1\]\[\"DIRS\"\] = _make_mako_template_dirs|TEMPLATES[1][\"DIRS\"] = _make_mako_template_dirs|" "$DEVSTACK_FILE"
+sed -i '' "s|^# TEMPLATES\[1\]\[\"DIRS\"\] = Derived(_make_mako_template_dirs)|TEMPLATES[1][\"DIRS\"] = Derived(_make_mako_template_dirs)|" "$DEVSTACK_FILE"
 sed -i '' "s|^# derive_settings(__name__)|derive_settings(__name__)|" "$DEVSTACK_FILE"
 
 

--- a/provision-set-edx-theme.sh
+++ b/provision-set-edx-theme.sh
@@ -4,7 +4,7 @@
 
 REPO_URL="git@github.com:edx/edx-themes.git"
 THEME_DIR="/edx/src/edx-themes/edx-platform"
-DEVSTACK_FILE="../edx-platform/lms/envs/devstack.py"
+DEVSTACK_FILE="./py_configuration_files/lms.py"
 
 # Clone the edx-themes repository into the src directory
 cd ../src


### PR DESCRIPTION
Two changes:
1. By default, we clone repos with SSH now. Update the REPO_URL accordingly.
2. Updates the relevant lines to setup to setup comprehensive theming correctly.

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
