### PR TITLE
fix: Run codejail with app user; more docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -731,6 +731,7 @@ services:
       DJANGO_SETTINGS_MODULE: codejail_service.settings.devstack
     ports:
       - "18030:8080"
+    user: app
     security_opt:
       - apparmor=openedx_codejail_service
 

--- a/docs/codejail.rst
+++ b/docs/codejail.rst
@@ -43,4 +43,4 @@ To check whether the profile has been applied, run ``sudo aa-status | grep codej
 
 If you need to debug the confinement, either because it is restricting too much or too little, a good strategy is to run ``tail -F /var/log/kern.log | grep codejail`` and watch for ``DENIED`` lines. You should expect to see several appear during service startup, as the service is designed to probe the confinement as part of its initial healthcheck.
 
-Unlike other devstack services, this one runs as the ``app`` user rather than as ``root``. In order to enter the container as root, you can use ``docker compose exec -it --user root codejail bash`` rather than ``make codejail-shell``.
+Unlike other devstack services, this one runs as the ``app`` user rather than as ``root``. (Although this isn't strictly needed to develop, it better matches our production environment, and allows proper testing of several aspects of the sandboxing.) In order to enter the container as root, you can use ``docker compose exec -it --user root codejail bash`` rather than ``make codejail-shell``.

--- a/docs/codejail.rst
+++ b/docs/codejail.rst
@@ -42,3 +42,5 @@ Debugging
 To check whether the profile has been applied, run ``sudo aa-status | grep codejail``. This won't tell you if the profile is out of date, but it will tell you if you have *some* version of it installed.
 
 If you need to debug the confinement, either because it is restricting too much or too little, a good strategy is to run ``tail -F /var/log/kern.log | grep codejail`` and watch for ``DENIED`` lines. You should expect to see several appear during service startup, as the service is designed to probe the confinement as part of its initial healthcheck.
+
+Unlike other devstack services, this one runs as the ``app`` user rather than as ``root``. In order to enter the container as root, you can use ``docker compose exec -it --user root codejail bash`` rather than ``make codejail-shell``.

--- a/py_configuration_files/codejail.py
+++ b/py_configuration_files/codejail.py
@@ -26,7 +26,11 @@ CODE_JAIL = {
         # Need at least 300 MiB memory for matplotlib alone. 512 MiB should be
         # enough headroom in general.
         'VMEM': 512 * 1024 * 1024,
-        # 1 MB file write limit
+        # 1 MB file size limit
         'FSIZE': 1 * 1024 * 1024,
+        # 15 processes and threads (codejail default)
+        'NPROC': 15,
+        # Match production configuration
+        'PROXY': 0,
     },
 }


### PR DESCRIPTION
- Use `app` user by default; may need to switch back to `root` at some point for ease of development, but for now let's try to keep it as similar as possible to stage and prod so that we can find issues sooner.
- Document the situation, and note how to enter as root (same as for any container, but may be helpful in this uncommon situation).
- Correct comment for `FSIZE`
- Copy `NPROC` and `PROXY` defaults into settings for reference

This depends on https://github.com/edx/edx-arch-experiments/issues/983, otherwise the service will start failing.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
