### PR TITLE
build: update analytics-data-api docker image name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -561,7 +561,7 @@ services:
       - ${PWD}/configuration_files/insights.yml:/edx/etc/insights.yml
 
   analyticsapi:
-    image: edxops/analytics-api-dev:latest
+    image: edxops/edx-analytics-data-api-dev:latest
     container_name: edx.devstack.analyticsapi
     hostname: analyticsapi
     depends_on:


### PR DESCRIPTION
## Description
- Since the Dockerfiles migration and consolidation into the `public-dockerfiles` repository, the image name for the analytics-data-api service has been renamed as per the convention of the other images. 
- Updated the image name in `docker-compose.yml` to use the latest image being published on dockerhub through public-dockerfiles workflows

## Testing
- The latest docker-compose.yml has been tested to be working perfectly locally for the analytics-data-api service by running `make dev.up.analyticsapi` locally.