### PR TITLE
fix: correct dir for enterprise-catalog provisioning

### DIFF
--- a/provision-enterprise-catalog.sh
+++ b/provision-enterprise-catalog.sh
@@ -5,14 +5,14 @@ docker compose up -d $name
 
 # Run migrations
 echo -e "${GREEN}Running migrations for ${name}...${NC}"
-docker compose exec -T ${name} bash -c "cd /edx/app/${name}/${name}/ && make migrate"
+docker compose exec -T ${name} bash -c "cd /edx/app/${name}/ && make migrate"
 
 echo -e "${GREEN}Installing requirements for ${name}...${NC}"
 docker compose exec -T ${name}  bash -e -c 'cd /edx/app/enterprise-catalog/ && make requirements' -- "$name"
 
 # Create superuser
 echo -e "${GREEN}Creating super-user for ${name}...${NC}"
-docker compose exec -T ${name} bash -c "echo 'from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None' | python /edx/app/${name}/${name}/manage.py shell"
+docker compose exec -T ${name} bash -c "echo 'from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser(\"edx\", \"edx@example.com\", \"edx\") if not User.objects.filter(username=\"edx\").exists() else None' | python /edx/app/${name}/manage.py shell"
 
 ./provision-ida-user.sh ${name} ${name} ${port}
 


### PR DESCRIPTION
Noticed this on a fresh devstack:

```
Running migrations for enterprise-catalog...
bash: line 0: cd: /edx/app/enterprise-catalog/enterprise-catalog/: No such file or directory
```

and enterprise-catalog service wouldn't start because no migrations were run.

Sure enough, for whatever reason the directory has changed.  Confirming by observation:

```
@pwnage101 ➜ /workspaces/devstack $ make enterprise-catalog-shell
docker compose exec enterprise-catalog /bin/bash
root@enterprise-catalog:/edx/app/enterprise-catalog# ls
api-compact.yaml   codecov.yml               docs                Makefile              pylintrc          README.rst        scripts    validate.sh
api.yaml           db_keyword_overrides.yml  enterprise_catalog  manage.py             pylintrc_tweaks   requirements      setup.cfg
catalog-info.yaml  docker-compose.yml        LICENSE             provision-catalog.sh  pytest.local.ini  requirements.txt  tox.ini
```