### PR TITLE
feat: repo.sh - shallow cloning still tracks remote branches.

### DIFF
--- a/repo.sh
+++ b/repo.sh
@@ -164,6 +164,11 @@ _clone ()
             fi
             if [ "${SHALLOW_CLONE}" == "1" ]; then
                 git clone ${CLONE_BRANCH} -c core.symlinks=true --depth=1 "${repo}"
+                # Set up developers for success by tracking all remote branches, otherwise remote branches
+                # cannot be checked-out. This only edits a text file, so it adds negligible time.
+                pushd "${name}"
+                git remote set-branches origin '*'
+                popd
             else
                 git clone ${CLONE_BRANCH} -c core.symlinks=true "${repo}"
             fi


### PR DESCRIPTION
When setting SHALLOW_CLONE=1 setting for the `make dev.clone` target, developers are left with clones which cannot checkout remote branches for development. They are forced to search stackoverflow and ask AI bots how to fix this problem and discover an obscure command to fix their local clone.

This PR just captures that work so others don't suffer.