### PR TITLE
fix: Many fixes for enterprise IDAs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,7 @@ dev.shell.insights:
 	docker compose exec insights env TERM=$(TERM) bash -c 'eval $$(source /edx/app/insights/insights_env; echo PATH="$$PATH";) && /bin/bash'
 
 dev.shell.%: ## Run a shell on the specified service's container.
-	docker compose exec $* /bin/bash
+	docker compose exec -u 0 $* /bin/bash
 
 dev.dbshell:
 	docker compose exec mysql80 bash -c "mysql"

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -24,10 +24,12 @@ services:
     volumes:
       - ${DEVSTACK_WORKSPACE}/enterprise-access:/edx/app/enterprise-access/
       - ${DEVSTACK_WORKSPACE}/src:/edx/src
-      - ${PWD}/py_configuration_files/enterprise_access.py:/edx/app/enterprise-access/license_manager/settings/devstack.py
+      - ${PWD}/py_configuration_files/enterprise_access.py:/edx/app/enterprise-access/enterprise_access/settings/devstack.py
   enterprise-access-worker:
     volumes:
       - ${DEVSTACK_WORKSPACE}/enterprise-access:/edx/app/enterprise-access/
+      - ${DEVSTACK_WORKSPACE}/src:/edx/src
+      - ${PWD}/py_configuration_files/enterprise_access.py:/edx/app/enterprise-access/enterprise_access/settings/devstack.py
   forum:
     volumes:
       - ${DEVSTACK_WORKSPACE}/cs_comments_service:/edx/app/forum/cs_comments_service
@@ -98,15 +100,15 @@ services:
 
   enterprise-catalog:
     volumes:
-      - ${DEVSTACK_WORKSPACE}/enterprise-catalog:/edx/app/enterprise_catalog/enterprise_catalog
-      - ${PWD}/py_configuration_files/enterprise_catalog.py:/edx/app/enterprise_catalog/enterprise_catalog/settings/devstack.py
+      - ${DEVSTACK_WORKSPACE}/enterprise-catalog:/edx/app/enterprise-catalog
+      - ${PWD}/py_configuration_files/enterprise_catalog.py:/edx/app/enterprise-catalog/enterprise_catalog/settings/devstack.py
   enterprise-catalog-worker:
     volumes:
-      - ${DEVSTACK_WORKSPACE}/enterprise-catalog:/edx/app/enterprise_catalog/enterprise_catalog
-      - ${PWD}/py_configuration_files/enterprise_catalog.py:/edx/app/enterprise_catalog/enterprise_catalog/settings/devstack.py
+      - ${DEVSTACK_WORKSPACE}/enterprise-catalog:/edx/app/enterprise-catalog
+      - ${PWD}/py_configuration_files/enterprise_catalog.py:/edx/app/enterprise-catalog/enterprise_catalog/settings/devstack.py
   enterprise-catalog-curations-worker:
     volumes:
-      - ${DEVSTACK_WORKSPACE}/enterprise-catalog:/edx/app/enterprise_catalog/enterprise_catalog
+      - ${DEVSTACK_WORKSPACE}/enterprise-catalog:/edx/app/enterprise-catalog
   license-manager:
     volumes:
       - ${DEVSTACK_WORKSPACE}/license-manager:/edx/app/license_manager

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -744,7 +744,7 @@ services:
     image: edxops/enterprise-catalog-dev
     container_name: edx.devstack.enterprise-catalog
     hostname: enterprise-catalog.devstack.edx
-    command: bash -c 'while true; do python /edx/app/enterprise_catalog/enterprise_catalog/manage.py runserver 0.0.0.0:18160; sleep 2; done'
+    command: bash -c 'while true; do python /edx/app/enterprise-catalog/manage.py runserver 0.0.0.0:18160; sleep 2; done'
     ports:
       - "18160:18160"
     depends_on:
@@ -774,9 +774,10 @@ services:
 
   enterprise-catalog-worker:
     image: edxops/enterprise-catalog-dev
-    command: bash -c 'cd /edx/app/enterprise_catalog/enterprise_catalog && celery -A enterprise_catalog worker -Q enterprise_catalog.default -l DEBUG'
+    command: bash -c 'cd /edx/app/enterprise-catalog && celery -A enterprise_catalog worker -Q enterprise_catalog.default -l DEBUG'
     container_name: edx.devstack.enterprise.catalog.worker
     depends_on:
+      - memcached
       - mysql80
     environment:
       CELERY_ALWAYS_EAGER: 'false'
@@ -796,7 +797,7 @@ services:
 
   enterprise-catalog-curations-worker:
     image: edxops/enterprise-catalog-dev
-    command: bash -c 'cd /edx/app/enterprise_catalog/enterprise_catalog && celery -A enterprise_catalog worker -Q enterprise_catalog.curations -l DEBUG'
+    command: bash -c 'cd /edx/app/enterprise-catalog && celery -A enterprise_catalog worker -Q enterprise_catalog.curations -l DEBUG'
     container_name: enterprise.catalog.curations
     depends_on:
       - mysql80

--- a/provision-enterprise-catalog.sh
+++ b/provision-enterprise-catalog.sh
@@ -16,5 +16,10 @@ docker compose exec -T ${name} bash -c "echo 'from django.contrib.auth import ge
 
 ./provision-ida-user.sh ${name} ${name} ${port}
 
+# Create system wide enterprise role assignment
+# TODO: this is a pretty complex oneline, we should probably eventually convert this to a management command.
+echo -e "${GREEN}Creating system wide enterprise user role assignment for ${name}...${NC}"
+docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && echo 'from django.contrib.auth import get_user_model; from enterprise.models import SystemWideEnterpriseUserRoleAssignment, SystemWideEnterpriseRole; User = get_user_model(); worker_user = User.objects.get(username=\"${name}_worker\"); operator_role = SystemWideEnterpriseRole.objects.get(name=\"enterprise_openedx_operator\"); assignment = SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(user=worker_user, role=operator_role, applies_to_all_contexts=True);' | /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms shell" -- lms
+
 # Restart enterprise.catalog app and worker containers
 docker compose restart enterprise-catalog enterprise-catalog-worker

--- a/provision-enterprise-subsidy.sh
+++ b/provision-enterprise-subsidy.sh
@@ -22,3 +22,10 @@ docker compose exec ${name} bash -c "echo 'from django.contrib.auth import get_u
 echo -e "${GREEN}Provisioning ${name}_worker in LMS...${NC}"
 
 ./provision-ida-user.sh ${name} ${name} ${port}
+
+# Create system wide enterprise role assignment
+# TODO: this is a pretty complex oneline, we should probably eventually convert this to a management command.
+echo -e "${GREEN}Creating system wide enterprise user role assignment for ${name}...${NC}"
+docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && echo 'from django.contrib.auth import get_user_model; from enterprise.models import SystemWideEnterpriseUserRoleAssignment, SystemWideEnterpriseRole; User = get_user_model(); worker_user = User.objects.get(username=\"${name}_worker\"); operator_role = SystemWideEnterpriseRole.objects.get(name=\"enterprise_openedx_operator\"); assignment = SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(user=worker_user, role=operator_role, applies_to_all_contexts=True);' | /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms shell" -- lms
+
+make dev.restart-devserver.enterprise-subsidy

--- a/provision-license-manager.sh
+++ b/provision-license-manager.sh
@@ -30,4 +30,9 @@ docker compose exec -T ${name} bash -e -c "echo 'from django.contrib.auth import
 # Provision IDA User in LMS
 ./provision-ida-user.sh ${name} ${name} $port
 
+# Create system wide enterprise role assignment
+# TODO: this is a pretty complex oneline, we should probably eventually convert this to a management command.
+echo -e "${GREEN}Creating system wide enterprise user role assignment for ${name}...${NC}"
+docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && echo 'from django.contrib.auth import get_user_model; from enterprise.models import SystemWideEnterpriseUserRoleAssignment, SystemWideEnterpriseRole; User = get_user_model(); worker_user = User.objects.get(username=\"${name}_worker\"); operator_role = SystemWideEnterpriseRole.objects.get(name=\"enterprise_openedx_operator\"); assignment = SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(user=worker_user, role=operator_role, applies_to_all_contexts=True);' | /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms shell" -- lms
+
 make dev.restart-devserver.license-manager

--- a/py_configuration_files/enterprise_access.py
+++ b/py_configuration_files/enterprise_access.py
@@ -4,9 +4,9 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': os.environ.get('DB_NAME', 'enterprise_access'),
-        'USER': os.environ.get('DB_USER', 'root'),
-        'PASSWORD': os.environ.get('DB_PASSWORD', ''),
-        'HOST': os.environ.get('DB_HOST', 'enterprise_access.mysql80'),
+        'USER': os.environ.get('DB_USER', 'enterprise_access001'),
+        'PASSWORD': os.environ.get('DB_PASSWORD', 'password'),
+        'HOST': os.environ.get('DB_HOST', 'edx.devstack.mysql80'),
         'PORT': os.environ.get('DB_PORT', 3306),
         'ATOMIC_REQUESTS': False,
         'CONN_MAX_AGE': 60,
@@ -17,7 +17,7 @@ DATABASES = {
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'LOCATION': 'enterprise_access.memcache:11211',
+        'LOCATION': 'edx.devstack.memcached:11211',
     }
 }
 
@@ -26,8 +26,8 @@ CACHES = {
 OAUTH2_PROVIDER_URL = 'http://edx.devstack.lms:18000/oauth2'
 
 # OAuth2 variables specific to social-auth/SSO login use case.
-SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_KEY', 'enterprise_access-sso-key')
-SOCIAL_AUTH_EDX_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET', 'enterprise_access-sso-secret')
+SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_KEY', 'enterprise-access-sso-key')
+SOCIAL_AUTH_EDX_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET', 'enterprise-access-sso-secret')
 SOCIAL_AUTH_EDX_OAUTH2_ISSUER = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_ISSUER', 'http://localhost:18000')
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT', 'http://edx.devstack.lms:18000')
 SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL', 'http://localhost:18000/logout')
@@ -37,9 +37,9 @@ SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = os.environ.get(
 
 # OAuth2 variables specific to backend service API calls.
 BACKEND_SERVICE_EDX_OAUTH2_KEY = os.environ.get(
-    'BACKEND_SERVICE_EDX_OAUTH2_KEY', 'enterprise_access-backend-service-key')
+    'BACKEND_SERVICE_EDX_OAUTH2_KEY', 'enterprise-access-backend-service-key')
 BACKEND_SERVICE_EDX_OAUTH2_SECRET = os.environ.get(
-    'BACKEND_SERVICE_EDX_OAUTH2_SECRET', 'enterprise_access-backend-service-secret')
+    'BACKEND_SERVICE_EDX_OAUTH2_SECRET', 'enterprise-access-backend-service-secret')
 
 JWT_AUTH.update({
     'JWT_SECRET_KEY': 'lms-secret',
@@ -91,13 +91,13 @@ CSRF_TRUSTED_ORIGINS = [
 # END CSRF CONFIG
 
 ECOMMERCE_URL = 'http://edx.devstack.ecommerce:18130'
-LICENSE_MANAGER_URL = 'http://license-manager.app:18170'
+LICENSE_MANAGER_URL = 'http://edx.devstack.license-manager:18170'
 LMS_URL = 'http://edx.devstack.lms:18000'
 DISCOVERY_URL = 'http://edx.devstack.discovery:18381'
 ENTERPRISE_LEARNER_PORTAL_URL = 'http://localhost:8734'
 ENTERPRISE_ADMIN_PORTAL_URL = 'http://localhost:1991'
-ENTERPRISE_CATALOG_URL = 'http://enterprise.catalog.app:18160'
-ENTERPRISE_SUBSIDY_URL = 'http://enterprise-subsidy.app:18280'
+ENTERPRISE_CATALOG_URL = 'http://edx.devstack.enterprise-catalog:18160'
+ENTERPRISE_SUBSIDY_URL = 'http://edx.devstack.enterprise-subsidy:18280'
 ENTERPRISE_ACCESS_URL = 'http://localhost:18270'
 
 # shell_plus

--- a/py_configuration_files/enterprise_catalog.py
+++ b/py_configuration_files/enterprise_catalog.py
@@ -4,8 +4,8 @@ from enterprise_catalog.settings.local import *
 OAUTH2_PROVIDER_URL = 'http://edx.devstack.lms:18000/oauth2'
 
 # OAuth2 variables specific to social-auth/SSO login use case.
-SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_KEY', 'enterprise_catalog-sso-key')
-SOCIAL_AUTH_EDX_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET', 'enterprise_catalog-sso-secret')
+SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_KEY', 'enterprise-catalog-sso-key')
+SOCIAL_AUTH_EDX_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET', 'enterprise-catalog-sso-secret')
 SOCIAL_AUTH_EDX_OAUTH2_ISSUER = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_ISSUER', 'http://localhost:18000')
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT', 'http://edx.devstack.lms:18000')
 SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL', 'http://localhost:18000/logout')
@@ -14,8 +14,8 @@ SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = os.environ.get(
 )
 
 # OAuth2 variables specific to backend service API calls.
-BACKEND_SERVICE_EDX_OAUTH2_KEY = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_KEY', 'enterprise_catalog-backend-service-key')
-BACKEND_SERVICE_EDX_OAUTH2_SECRET = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET', 'enterprise_catalog-backend-service-secret')
+BACKEND_SERVICE_EDX_OAUTH2_KEY = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_KEY', 'enterprise-catalog-backend-service-key')
+BACKEND_SERVICE_EDX_OAUTH2_SECRET = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET', 'enterprise-catalog-backend-service-secret')
 
 JWT_AUTH.update({
     'JWT_SECRET_KEY': 'lms-secret',
@@ -39,9 +39,9 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': os.environ.get('DB_NAME', 'enterprise_catalog'),
-        'USER': os.environ.get('DB_USER', 'root'),
-        'PASSWORD': os.environ.get('DB_PASSWORD', ''),
-        'HOST': os.environ.get('DB_HOST', 'enterprise.catalog.mysql'),
+        'USER': os.environ.get('DB_USER', 'catalog001'),
+        'PASSWORD': os.environ.get('DB_PASSWORD', 'password'),
+        'HOST': os.environ.get('DB_HOST', 'edx.devstack.mysql80'),
         'PORT': os.environ.get('DB_PORT', 3306),
         'ATOMIC_REQUESTS': False,
         'CONN_MAX_AGE': 60,
@@ -84,7 +84,7 @@ CORS_ORIGIN_WHITELIST = [
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        'LOCATION': 'enterprise.catalog.memcached:11211',
+        'LOCATION': 'edx.devstack.memcached:11211',
     }
 }
 

--- a/py_configuration_files/enterprise_subsidy.py
+++ b/py_configuration_files/enterprise_subsidy.py
@@ -16,9 +16,9 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': os.environ.get('DB_NAME', 'enterprise_subsidy'),
-        'USER': os.environ.get('DB_USER', 'root'),
-        'PASSWORD': os.environ.get('DB_PASSWORD', ''),
-        'HOST': os.environ.get('DB_HOST', 'enterprise-subsidy.mysql80'),
+        'USER': os.environ.get('DB_USER', 'subsidy001'),
+        'PASSWORD': os.environ.get('DB_PASSWORD', 'password'),
+        'HOST': os.environ.get('DB_HOST', 'edx.devstack.mysql80'),
         'PORT': os.environ.get('DB_PORT', 3306),
         'ATOMIC_REQUESTS': False,
         'CONN_MAX_AGE': 60,
@@ -77,7 +77,7 @@ JWT_AUTH.update({
 })
 
 LMS_URL = 'http://edx.devstack.lms:18000'
-ENTERPRISE_CATALOG_URL = 'http://enterprise.catalog.app:18160'
+ENTERPRISE_CATALOG_URL = 'http://edx.devstack.enterprise-catalog:18160'
 ENTERPRISE_SUBSIDY_URL = 'http://localhost:18280'
 FRONTEND_APP_LEARNING_URL = 'http://localhost:2000'
 

--- a/py_configuration_files/license_manager.py
+++ b/py_configuration_files/license_manager.py
@@ -18,8 +18,8 @@ DATABASES = {
 }
 
 # OAuth2 variables specific to social-auth/SSO login use case.
-SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_KEY', 'license_manager-sso-key')
-SOCIAL_AUTH_EDX_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET', 'license_manager-sso-secret')
+SOCIAL_AUTH_EDX_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_KEY', 'license-manager-sso-key')
+SOCIAL_AUTH_EDX_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_SECRET', 'license-manager-sso-secret')
 SOCIAL_AUTH_EDX_OAUTH2_ISSUER = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_ISSUER', 'http://localhost:18000')
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT', 'http://edx.devstack.lms:18000')
 SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL = os.environ.get('SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL', 'http://localhost:18000/logout')
@@ -28,8 +28,8 @@ SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = os.environ.get(
 )
 
 # OAuth2 variables specific to backend service API calls.
-BACKEND_SERVICE_EDX_OAUTH2_KEY = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_KEY', 'license_manager-backend-service-key')
-BACKEND_SERVICE_EDX_OAUTH2_SECRET = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET', 'license_manager-backend-service-secret')
+BACKEND_SERVICE_EDX_OAUTH2_KEY = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_KEY', 'license-manager-backend-service-key')
+BACKEND_SERVICE_EDX_OAUTH2_SECRET = os.environ.get('BACKEND_SERVICE_EDX_OAUTH2_SECRET', 'license-manager-backend-service-secret')
 
 JWT_AUTH.update({
     'JWT_SECRET_KEY': 'lms-secret',
@@ -74,7 +74,7 @@ CSRF_TRUSTED_ORIGINS = [
 # END CSRF CONFIG
 
 ENTERPRISE_LEARNER_PORTAL_BASE_URL = 'http://localhost:8734'
-ENTERPRISE_CATALOG_URL = 'http://enterprise.catalog.app:18160'
+ENTERPRISE_CATALOG_URL = 'http://edx.devstack.enterprise-catalog:18160'
 LMS_URL = 'http://edx.devstack.lms:18000'
 SUPPORT_SITE_URL = 'https://support.edx.org'
 


### PR DESCRIPTION
It seems like the various enterprise-specific devstack settings are a mix of legacy stuff combined with failed attempts to port repo-specific devstack configs into this central devstack repo. As a result, the various hostnames and paths are completely broken. This hasn't impacted us because we normally don't use enterprise inside of devstack, but this is will hopefully be our future.