### PR TITLE
fix: minimize repo permissions requested for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,9 @@
         "codespaces": {
             "repositories": {
                 "edx/edx-themes": {
-                    "permissions": "read-all"
+                    "permissions": {
+                        "contents": "read"
+                    }
                 }
             }
         }


### PR DESCRIPTION
We only need to check out this repo, which is just the `contents` permission.