### PR TITLE
fix: clone repos outside of devstack clone

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
         }
     },
     "containerEnv": {
-        "DEVSTACK_WORKSPACE": "${containerWorkspaceFolder}/edx-repos"
+        "DEVSTACK_WORKSPACE": "/workspaces/edx-repos"
     },
     "updateContentCommand": ".devcontainer/updateContentCommand.sh",
     "postCreateCommand": ".devcontainer/postCreateCommand.sh",


### PR DESCRIPTION
This makes it possible to add each clone (as needed) as a new root workspace in VS Code.

![Screenshot 2025-05-29 at 8 39 34 AM](https://github.com/user-attachments/assets/f6211408-517e-44bf-9dfe-e69c6e4e5949)
![Screenshot 2025-05-29 at 8 40 47 AM](https://github.com/user-attachments/assets/6665dea8-b8a5-43cb-86d8-bdbba202dc0a)
