### PR TITLE
[AU-2523] codespaces devstack collision port 2000 for frontend-app-learning

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,8 +36,8 @@
     "postCreateCommand": ".devcontainer/postCreateCommand.sh",
     "postStartCommand": ".devcontainer/postStartCommand.sh",
     "forwardPorts": [
-        1976, 1984, 1990, 1991, 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2000,
-        2001, 3001, 3406, 5335, 7474, 8000, 8081, 8734, 8735, 9021, 9201, 9202,
+        1976, 1984, 1990, 1991, 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2001,
+        2010, 3001, 3406, 5335, 7474, 8000, 8081, 8734, 8735, 9021, 9201, 9202,
         9301, 9600, 18000, 18010, 18040, 18110, 18120, 18130, 18150, 18160,
         18170, 18270, 18280, 18381, 18400, 18450, 18734, 18760, 18787, 19001,
         27017, 44567
@@ -60,7 +60,7 @@
         "18130": { "label": "ecommerce" },
         "18150": { "label": "credentials" },
         "18120": { "label": "edx_notes_api" },
-        "2000":  { "label": "frontend-app-learning" },
+        "2010":  { "label": "frontend-app-learning" },
         "1998":  { "label": "frontend-app-payment" },
         "18400": { "label": "frontend-app-publisher" },
         "1994":  { "label": "frontend-app-gradebook" },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1103,7 +1103,7 @@ services:
         aliases:
           - edx.devstack.frontend-app-learning
     ports:
-      - "2010:2000"
+      - "2010:2000" # avoid Codespaces port 2000 conflict
     depends_on:
       - lms
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1103,7 +1103,7 @@ services:
         aliases:
           - edx.devstack.frontend-app-learning
     ports:
-      - "2000:2000"
+      - "2010:2000"
     depends_on:
       - lms
 

--- a/docs/service_list.rst
+++ b/docs/service_list.rst
@@ -31,7 +31,7 @@ Instead of a service name or list, you can also run commands like ``make dev.pro
 +------------------------------------+-------------------------------------+----------------+--------------+
 | `frontend-app-learner-record`_     | http://localhost:1990/              | MFE (React.js) | Default      |
 +------------------------------------+-------------------------------------+----------------+--------------+
-| `frontend-app-learning`_           | http://localhost:2000/              | MFE (React.js) | Default      |
+| `frontend-app-learning`_           | http://localhost:2010/              | MFE (React.js) | Default      |
 +------------------------------------+-------------------------------------+----------------+--------------+
 | `frontend-app-payment`_            | http://localhost:1998/              | MFE (React.js) | Default      |
 +------------------------------------+-------------------------------------+----------------+--------------+

--- a/docs/service_list.rst
+++ b/docs/service_list.rst
@@ -75,12 +75,15 @@ Instead of a service name or list, you can also run commands like ``make dev.pro
 +------------------------------------+-------------------------------------+----------------+--------------+
 | `enterprise-subsidy`_              | http://localhost:18280              | Python/Django  | Extra        |
 +------------------------------------+-------------------------------------+----------------+--------------+
+| **Reserved for Codespace**         | http://localhost:2000               | **Codespace**  | Default      |
++------------------------------------+-------------------------------------+----------------+--------------+
 
 Some common service combinations include:
 
 * ``lms``: LMS, along with dependencies ``forum``, ``discovery``, ``Authn`` and some databases
 * ``ecommerce``: Ecommerce, but also LMS as a dependency (for auth)
 * ``cms+credentials``: Services can be combined to affect both at once
+* **Reserved for Codespace**: The port `2000` is being used for github Codespace service & reserverd for Codespace use only.
 
 .. _credentials: https://github.com/openedx/credentials
 .. _discovery: https://github.com/openedx/course-discovery

--- a/docs/troubleshoot_general_tips.rst
+++ b/docs/troubleshoot_general_tips.rst
@@ -253,7 +253,7 @@ Update as of 2023-08-03: The issue was moved to https://2u-internal.atlassian.ne
 
 CORS error from login_refresh in MFE
 ------------------------------------
-If you see "Access to XMLHttpRequest at 'http://localhost:18000/login_refresh' from origin 'http://localhost:2000' has been blocked by CORS policy: Request header field x-xsrf-token is not allowed by Access-Control-Allow-Headers in preflight response" it usually means you don't have a valid session.
+If you see "Access to XMLHttpRequest at 'http://localhost:18000/login_refresh' from origin 'http://localhost:2010' has been blocked by CORS policy: Request header field x-xsrf-token is not allowed by Access-Control-Allow-Headers in preflight response" it usually means you don't have a valid session.
 
 The fix is to get a new auth session. You can do any of the following:
 

--- a/py_configuration_files/course_discovery.py
+++ b/py_configuration_files/course_discovery.py
@@ -18,7 +18,7 @@ CORS_ORIGIN_WHITELIST = (
     'http://localhost:1991',  # frontend-app-admin-portal
     'http://localhost:18400',  # frontend-app-publisher
     'http://localhost:18450',  # frontend-app-support-tools
-    'http://localhost:2010',  # frontend-app-learning (port changed from 2000 to 2010, due to conflict in codepsace)
+    'http://localhost:2010',  # frontend-app-learning
 )
 
 ELASTICSEARCH_DSL['default']['hosts'] = 'edx.devstack.elasticsearch710:9200'

--- a/py_configuration_files/course_discovery.py
+++ b/py_configuration_files/course_discovery.py
@@ -18,7 +18,7 @@ CORS_ORIGIN_WHITELIST = (
     'http://localhost:1991',  # frontend-app-admin-portal
     'http://localhost:18400',  # frontend-app-publisher
     'http://localhost:18450',  # frontend-app-support-tools
-    'http://localhost:2010',  # frontend-app-learning
+    'http://localhost:2010',  # frontend-app-learning (port changed from 2000 to 2010, due to conflict in codepsace)
 )
 
 ELASTICSEARCH_DSL['default']['hosts'] = 'edx.devstack.elasticsearch710:9200'

--- a/py_configuration_files/course_discovery.py
+++ b/py_configuration_files/course_discovery.py
@@ -18,7 +18,7 @@ CORS_ORIGIN_WHITELIST = (
     'http://localhost:1991',  # frontend-app-admin-portal
     'http://localhost:18400',  # frontend-app-publisher
     'http://localhost:18450',  # frontend-app-support-tools
-    'http://localhost:2000',  # frontend-app-learning
+    'http://localhost:2010',  # frontend-app-learning
 )
 
 ELASTICSEARCH_DSL['default']['hosts'] = 'edx.devstack.elasticsearch710:9200'

--- a/py_configuration_files/ecommerce.py
+++ b/py_configuration_files/ecommerce.py
@@ -55,7 +55,7 @@ CORS_ORIGIN_WHITELIST = (
     'http://localhost:1996',
     'http://localhost:1997', # Account MFE
     'http://localhost:1998',
-    'http://localhost:2010', # Learning MFE  (port changed from 2000 to 2010, due to conflict in codepsace)
+    'http://localhost:2010', # Learning MFE
     'http://localhost:8734', # Enterprise Learner Portal MFE
 )
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (

--- a/py_configuration_files/ecommerce.py
+++ b/py_configuration_files/ecommerce.py
@@ -55,7 +55,7 @@ CORS_ORIGIN_WHITELIST = (
     'http://localhost:1996',
     'http://localhost:1997', # Account MFE
     'http://localhost:1998',
-    'http://localhost:2010', # Learning MFE
+    'http://localhost:2010', # Learning MFE  (port changed from 2000 to 2010, due to conflict in codepsace)
     'http://localhost:8734', # Enterprise Learner Portal MFE
 )
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (

--- a/py_configuration_files/ecommerce.py
+++ b/py_configuration_files/ecommerce.py
@@ -55,7 +55,7 @@ CORS_ORIGIN_WHITELIST = (
     'http://localhost:1996',
     'http://localhost:1997', # Account MFE
     'http://localhost:1998',
-    'http://localhost:2000', # Learning MFE
+    'http://localhost:2010', # Learning MFE
     'http://localhost:8734', # Enterprise Learner Portal MFE
 )
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (

--- a/py_configuration_files/enterprise_subsidy.py
+++ b/py_configuration_files/enterprise_subsidy.py
@@ -75,7 +75,7 @@ JWT_AUTH.update({
 LMS_URL = 'http://edx.devstack.lms:18000'
 ENTERPRISE_CATALOG_URL = 'http://edx.devstack.enterprise-catalog:18160'
 ENTERPRISE_SUBSIDY_URL = 'http://localhost:18280'
-FRONTEND_APP_LEARNING_URL = 'http://localhost:2010'  # Learning MFE
+FRONTEND_APP_LEARNING_URL = 'http://localhost:2010'  # Learning MFE (port changed from 2000 to 2010, due to conflict in codepsace)
 
 # Kafka Settings
 # "Standard" Kafka settings as defined in https://github.com/openedx/event-bus-kafka/tree/main

--- a/py_configuration_files/enterprise_subsidy.py
+++ b/py_configuration_files/enterprise_subsidy.py
@@ -75,7 +75,7 @@ JWT_AUTH.update({
 LMS_URL = 'http://edx.devstack.lms:18000'
 ENTERPRISE_CATALOG_URL = 'http://edx.devstack.enterprise-catalog:18160'
 ENTERPRISE_SUBSIDY_URL = 'http://localhost:18280'
-FRONTEND_APP_LEARNING_URL = 'http://localhost:2010'  # Learning MFE (port changed from 2000 to 2010, due to conflict in codepsace)
+FRONTEND_APP_LEARNING_URL = 'http://localhost:2010'  # Learning MFE
 
 # Kafka Settings
 # "Standard" Kafka settings as defined in https://github.com/openedx/event-bus-kafka/tree/main

--- a/py_configuration_files/enterprise_subsidy.py
+++ b/py_configuration_files/enterprise_subsidy.py
@@ -75,7 +75,7 @@ JWT_AUTH.update({
 LMS_URL = 'http://edx.devstack.lms:18000'
 ENTERPRISE_CATALOG_URL = 'http://edx.devstack.enterprise-catalog:18160'
 ENTERPRISE_SUBSIDY_URL = 'http://localhost:18280'
-FRONTEND_APP_LEARNING_URL = 'http://localhost:2000'
+FRONTEND_APP_LEARNING_URL = 'http://localhost:2010'  # Learning MFE
 
 # Kafka Settings
 # "Standard" Kafka settings as defined in https://github.com/openedx/event-bus-kafka/tree/main

--- a/py_configuration_files/lms.py
+++ b/py_configuration_files/lms.py
@@ -304,7 +304,7 @@ LOGIN_REDIRECT_WHITELIST.extend([
     'localhost:1997',  # frontend-app-account
     'localhost:1976',  # frontend-app-program-console
     'localhost:1994',  # frontend-app-gradebook
-    'localhost:2010',  # frontend-app-learning
+    'localhost:2010',  # frontend-app-learning (port changed from 2000 to 2010, due to conflict in codepsace)
     'localhost:2001',  # frontend-app-course-authoring
     'localhost:3001',  # frontend-app-library-authoring
     'localhost:18400',  # frontend-app-publisher
@@ -382,7 +382,7 @@ EDXNOTES_INTERNAL_API = 'http://edx.devstack.edxnotesapi:18120/api/v1'
 EDXNOTES_CLIENT_NAME = 'edx_notes_api-backend-service'
 
 ############## Settings for Microfrontends  #########################
-LEARNING_MICROFRONTEND_URL = 'http://localhost:2010'
+LEARNING_MICROFRONTEND_URL = 'http://localhost:2010' # (port changed from 2000 to 2010, due to conflict in codepsace)
 ACCOUNT_MICROFRONTEND_URL = 'http://localhost:1997'
 PROFILE_MICROFRONTEND_URL = 'http://localhost:1995'
 COMMUNICATIONS_MICROFRONTEND_URL = 'http://localhost:1984'
@@ -542,7 +542,7 @@ AI_TRANSLATIONS_API_URL = 'http://localhost:18760/api/v1'
 
 # MFEs that will call this service in devstack
 CSRF_TRUSTED_ORIGINS = [
-    'http://localhost:2010',  # frontend-app-learning
+    'http://localhost:2010',  # frontend-app-learning (port changed from 2000 to 2010, due to conflict in codepsace)
     'http://localhost:2001',  # frontend-app-course-authoring
     'http://localhost:1997',  # frontend-app-account
     'http://localhost:1995',  # frontend-app-profile

--- a/py_configuration_files/lms.py
+++ b/py_configuration_files/lms.py
@@ -542,7 +542,7 @@ AI_TRANSLATIONS_API_URL = 'http://localhost:18760/api/v1'
 
 # MFEs that will call this service in devstack
 CSRF_TRUSTED_ORIGINS = [
-    'http://localhost:3000',  # frontend-app-learning
+    'http://localhost:2010',  # frontend-app-learning
     'http://localhost:2001',  # frontend-app-course-authoring
     'http://localhost:1997',  # frontend-app-account
     'http://localhost:1995',  # frontend-app-profile

--- a/py_configuration_files/lms.py
+++ b/py_configuration_files/lms.py
@@ -304,7 +304,7 @@ LOGIN_REDIRECT_WHITELIST.extend([
     'localhost:1997',  # frontend-app-account
     'localhost:1976',  # frontend-app-program-console
     'localhost:1994',  # frontend-app-gradebook
-    'localhost:2000',  # frontend-app-learning
+    'localhost:2010',  # frontend-app-learning
     'localhost:2001',  # frontend-app-course-authoring
     'localhost:3001',  # frontend-app-library-authoring
     'localhost:18400',  # frontend-app-publisher
@@ -382,7 +382,7 @@ EDXNOTES_INTERNAL_API = 'http://edx.devstack.edxnotesapi:18120/api/v1'
 EDXNOTES_CLIENT_NAME = 'edx_notes_api-backend-service'
 
 ############## Settings for Microfrontends  #########################
-LEARNING_MICROFRONTEND_URL = 'http://localhost:2000'
+LEARNING_MICROFRONTEND_URL = 'http://localhost:2010'
 ACCOUNT_MICROFRONTEND_URL = 'http://localhost:1997'
 PROFILE_MICROFRONTEND_URL = 'http://localhost:1995'
 COMMUNICATIONS_MICROFRONTEND_URL = 'http://localhost:1984'
@@ -542,7 +542,7 @@ AI_TRANSLATIONS_API_URL = 'http://localhost:18760/api/v1'
 
 # MFEs that will call this service in devstack
 CSRF_TRUSTED_ORIGINS = [
-    'http://localhost:2000',  # frontend-app-learning
+    'http://localhost:3000',  # frontend-app-learning
     'http://localhost:2001',  # frontend-app-course-authoring
     'http://localhost:1997',  # frontend-app-account
     'http://localhost:1995',  # frontend-app-profile

--- a/py_configuration_files/lms.py
+++ b/py_configuration_files/lms.py
@@ -382,7 +382,7 @@ EDXNOTES_INTERNAL_API = 'http://edx.devstack.edxnotesapi:18120/api/v1'
 EDXNOTES_CLIENT_NAME = 'edx_notes_api-backend-service'
 
 ############## Settings for Microfrontends  #########################
-LEARNING_MICROFRONTEND_URL = 'http://localhost:2010' # (port changed from 2000 to 2010, due to conflict in codepsace)
+LEARNING_MICROFRONTEND_URL = 'http://localhost:2010'
 ACCOUNT_MICROFRONTEND_URL = 'http://localhost:1997'
 PROFILE_MICROFRONTEND_URL = 'http://localhost:1995'
 COMMUNICATIONS_MICROFRONTEND_URL = 'http://localhost:1984'
@@ -542,7 +542,7 @@ AI_TRANSLATIONS_API_URL = 'http://localhost:18760/api/v1'
 
 # MFEs that will call this service in devstack
 CSRF_TRUSTED_ORIGINS = [
-    'http://localhost:2010',  # frontend-app-learning (port changed from 2000 to 2010, due to conflict in codepsace)
+    'http://localhost:2010',  # frontend-app-learning
     'http://localhost:2001',  # frontend-app-course-authoring
     'http://localhost:1997',  # frontend-app-account
     'http://localhost:1995',  # frontend-app-profile


### PR DESCRIPTION
Due to github codespace mapping system port 2000 & had a collision with `make dev.up` we had to fix the ports for `frontend-app-learning`

- Fixed docker-compose.yml port mapping for `frontend-app-learning` to 2010
- Updated referred files for cors or request site mapping 
- Updated documentation
- Updated devcontainer.json for codepace forward port mapping