### PR TITLE
feat: update most MFE configs to elm-theme

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -960,7 +960,7 @@ services:
     working_dir: '/edx/app/frontend-app-account'
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.frontend-app-account"
     environment:
-      PARAGON_BRAND_PACKAGE: '@edx/brand-edx.org@1.x'
+      PARAGON_BRAND_PACKAGE: '@edx/elm-theme@1.x'
     networks:
       default:
         aliases:
@@ -1003,7 +1003,7 @@ services:
     working_dir: '/edx/app/frontend-app-profile'
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.frontend-app-profile"
     environment:
-      PARAGON_BRAND_PACKAGE: '@edx/brand-edx.org@~2.0.0'
+      PARAGON_BRAND_PACKAGE: '@edx/elm-theme@1.x'
     networks:
       default:
         aliases:
@@ -1020,7 +1020,7 @@ services:
     working_dir: '/edx/app/frontend-app-authn'
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.frontend-app-authn"
     environment:
-      PARAGON_BRAND_PACKAGE: '@edx/brand-edx.org@2.x'
+      PARAGON_BRAND_PACKAGE: '@edx/elm-theme@1.x'
     networks:
       default:
         aliases:
@@ -1037,7 +1037,7 @@ services:
     working_dir: '/edx/app/frontend-app-course-authoring'
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.frontend-app-course-authoring"
     environment:
-      PARAGON_BRAND_PACKAGE: '@edx/brand-edx.org@2.x'
+      PARAGON_BRAND_PACKAGE: '@edx/elm-theme@1.x'
     networks:
       default:
         aliases:
@@ -1069,7 +1069,7 @@ services:
     working_dir: '/edx/app/frontend-app-ora-grading'
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.frontend-app-ora-grading"
     environment:
-      PARAGON_BRAND_PACKAGE: '@edx/brand-edx.org@2.x'
+      PARAGON_BRAND_PACKAGE: '@edx/elm-theme@1.x'
     networks:
       default:
         aliases:
@@ -1086,7 +1086,7 @@ services:
     working_dir: '/edx/app/frontend-app-learner-dashboard'
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.frontend-app-learner-dashboard"
     environment:
-      PARAGON_BRAND_PACKAGE: '@edx/brand-edx.org@2.x'
+      PARAGON_BRAND_PACKAGE: '@edx/elm-theme@1.x'
     networks:
       default:
         aliases:
@@ -1103,7 +1103,7 @@ services:
     working_dir: '/edx/app/frontend-app-learner-record'
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.frontend-app-learner-record"
     environment:
-      PARAGON_BRAND_PACKAGE: '@edx/brand-edx.org@~2.0.0'
+      PARAGON_BRAND_PACKAGE: '@edx/elm-theme@1.x'
     networks:
       default:
         aliases:
@@ -1190,7 +1190,7 @@ services:
     working_dir: '/edx/app/frontend-app-publisher'
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.frontend-app-publisher"
     environment:
-      PARAGON_BRAND_PACKAGE: '@edx/brand-edx.org@2.x'
+      PARAGON_BRAND_PACKAGE: '@edx/elm-theme@1.x'
     networks:
       default:
         aliases:


### PR DESCRIPTION
This updates the `PARAGON_BRAND_PACKAGE` field for most of our MFE services. This field is used when bringing up the service to determine what the `@edx/brand` package should be aliased to. 

By default, the `@edx/brand` package is [aliased to the open source brand](https://github.com/openedx/frontend-app-learner-dashboard/blob/master/package.json#L31) ([@openedx/brand-openedx](https://github.com/openedx/brand-openedx)). In our Stage and Production environments, we alias the package to [point to the private 2u/edX theme](https://github.com/edx/edx-internal/blob/master/frontends/frontend-app-learner-dashboard/prod_config.yml#L30). Previously this was `@edx/brand-edx.org` — [the old theme](https://github.com/edx/brand-edx.org). We have now switched to `@edx/elm-theme` — [the new theme](https://github.com/edx/elm-theme). The old theme does not support design tokens, which were introduced in Paragon v23 as the method for theming Paragon components. Without a brand package that provides design tokens, MFE builds will fail if they are using the latest code from master branches. Elm theme supports design tokens.

All master branches of the Open edX supported MFEs have been updated to Paragon v23 and now require design token support from the brand package.

It is worth noting that the configuration for 4 MFEs has been left unchanged in this PR. They are:

- frontend-app-library-authoring — this is a deprecated MFE so will most likely be removed from devstack soon
- frontend-app-payment — using a fork that is not fully caught up with the master branch; will soon be replaced by Commercetools checkout page from [commerce coordinator application](https://github.com/edx/commerce-coordinator)
- frontend-app-learning — using a fork that is not fully caught up with the master branch
- frontend-app-program-console — using a fork that is not fully caught up with the master branch

Until the forked repositories have been upgraded to Paragon v23 and have support for design tokens, the configuration can not be changed. Dev builds would fail if we try to use `@edx/elm-theme` without that support.



## Testing instructions

- Pull down this branch
- Pick an MFE to test — ex. Learner Dashboard
- Run `make dev.remove-containers.frontend-app-learner-dashboard` to bring down the service (if it's already running)
- Run `make dev.up.frontend-app-learner-dashboard`
- Make sure you are logged in (localhost:18000) and then go to localhost:1996 to view the dashboard
- If you are enrolled in a course, you should see something that looks like this:

<img width="1147" height="889" alt="Screenshot 2025-07-15 at 12 06 53 PM" src="https://github.com/user-attachments/assets/b19a71b2-f562-489b-806d-33615e069b38" />

### If you want to test what it looked like before

#### You can either:

- Switch to the master branch

#### OR

- Modify the line for `PARAGON_BRAND_PACKAGE` and instead set it to `@edx/brand-edx.org@2.x`

#### THEN,

- Bring the service down (`make dev.remove-containers.frontend-app-learner-dashboard`)
- Bring the service back up (`make dev.remove-containers.frontend-app-learner-dashboard`)
- Check the dashboard at localhost:1996 and you should see the old theme (see image below)

<img width="894" height="725" alt="Screenshot 2025-07-15 at 10 31 05 AM" src="https://github.com/user-attachments/assets/e4ad6c0f-5221-4b05-a085-18d81f1ec5a4" />

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
