### PR TITLE
fix: Remove usages of devstack_docker.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -428,10 +428,10 @@ dev.static: | $(_asset_compilation_targets)
 EDXAPP_STATIC_ROOT_ENV=STATIC_ROOT_LMS=/edx/var/edxapp/staticfiles STATIC_ROOT_CMS=/edx/var/edxapp/staticfiles/studio
 
 dev.static.lms:
-	docker compose exec -T lms bash -c "source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && $(EDXAPP_STATIC_ROOT_ENV) npm run build-dev && ./manage.py lms collectstatic --no-input --settings devstack_docker"
+	docker compose exec -T lms bash -c "source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && $(EDXAPP_STATIC_ROOT_ENV) npm run build-dev && ./manage.py lms collectstatic --no-input --settings devstack"
 
 dev.static.cms:
-	docker compose exec -T cms bash -c "source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && $(EDXAPP_STATIC_ROOT_ENV) npm run build-dev && ./manage.py cms collectstatic --no-input --settings devstack_docker"
+	docker compose exec -T cms bash -c "source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && $(EDXAPP_STATIC_ROOT_ENV) npm run build-dev && ./manage.py cms collectstatic --no-input --settings devstack"
 
 dev.static.%: ## Rebuild static assets for the specified service's container.
 	docker compose exec -T $* bash -c 'source /edx/app/$*/$*_env && cd /edx/app/$*/$*/ && make static'

--- a/configuration_files/cms.yml
+++ b/configuration_files/cms.yml
@@ -1,0 +1,553 @@
+# This file is an experimental extraction of /edx/etc/studio.yml from
+# a CMS devstack container.
+#
+# When devstack is configured to use the new `openedx/` images
+# instead of the old `edxops/edxapp` image, it will use this file
+# as input to cms/envs/production.py (and, in turn, cms/envs/devstack.py).
+# If you are using devstack with the `edxops/edxapp` image, though,
+# this file is NOT used.
+#
+# Q. Should I update this file when I update devstack.py?
+# A. You don't *have* to, because settings in devstack.py
+#    override these settings. But, it doesn't harm to also make them
+#    here in order to quell confusion. The hope is that we'll
+#    adpot OEP-45 eventually, which recommends against having
+#    a devstack.py at all.
+#
+# This is part of the effort to move our dev tools off of Ansible and
+# Paver, described here: https://github.com/openedx/devstack/pull/866
+# TODO: If the effort described above is abandoned, then this file should
+# probably be deleted.
+ACTIVATION_EMAIL_SUPPORT_LINK: ''
+AFFILIATE_COOKIE_NAME: dev_affiliate_id
+ALTERNATE_WORKER_QUEUES: lms
+ANALYTICS_DASHBOARD_NAME: Your Platform Name Here Insights
+ANALYTICS_DASHBOARD_URL: http://localhost:18110/courses
+AUTH_PASSWORD_VALIDATORS:
+-   NAME: django.contrib.auth.password_validation.UserAttributeSimilarityValidator
+-   NAME: common.djangoapps.util.password_policy_validators.MinimumLengthValidator
+    OPTIONS:
+        min_length: 2
+-   NAME: common.djangoapps.util.password_policy_validators.MaximumLengthValidator
+    OPTIONS:
+        max_length: 75
+AUTHORING_API_URL: https://example.com
+AWS_ACCESS_KEY_ID: null
+AWS_QUERYSTRING_AUTH: false
+AWS_S3_CUSTOM_DOMAIN: SET-ME-PLEASE (ex. bucket-name.s3.amazonaws.com)
+AWS_SECRET_ACCESS_KEY: null
+AWS_SES_REGION_ENDPOINT: email.us-east-1.amazonaws.com
+AWS_SES_REGION_NAME: us-east-1
+AWS_STORAGE_BUCKET_NAME: SET-ME-PLEASE (ex. bucket-name)
+BASE_COOKIE_DOMAIN: localhost
+BLOCK_STRUCTURES_SETTINGS:
+    COURSE_PUBLISH_TASK_DELAY: 30
+    TASK_DEFAULT_RETRY_DELAY: 30
+    TASK_MAX_RETRIES: 5
+BRANCH_IO_KEY: ''
+BUGS_EMAIL: bugs@example.com
+BULK_EMAIL_DEFAULT_FROM_EMAIL: no-reply@example.com
+BULK_EMAIL_EMAILS_PER_TASK: 500
+BULK_EMAIL_LOG_SENT_EMAILS: false
+CACHES:
+    celery:
+        BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
+            connect_timeout: 0.5
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
+        KEY_PREFIX: celery
+        LOCATION:
+        - edx.devstack.memcached:11211
+        TIMEOUT: '7200'
+    configuration:
+        BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
+            connect_timeout: 0.5
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
+        KEY_PREFIX: 78f87108afce
+        LOCATION:
+        - edx.devstack.memcached:11211
+    course_structure_cache:
+        BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
+            connect_timeout: 0.5
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
+        KEY_PREFIX: course_structure
+        LOCATION:
+        - edx.devstack.memcached:11211
+        TIMEOUT: '604800'
+    default:
+        BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            ignore_exc: true
+            no_delay: true
+            use_pooling: true
+            connect_timeout: 0.5
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
+        KEY_PREFIX: default
+        LOCATION:
+        - edx.devstack.memcached:11211
+        VERSION: '1'
+    general:
+        BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
+            connect_timeout: 0.5
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
+        KEY_PREFIX: general
+        LOCATION:
+        - edx.devstack.memcached:11211
+    mongo_metadata_inheritance:
+        BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
+            connect_timeout: 0.5
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
+        KEY_PREFIX: mongo_metadata_inheritance
+        LOCATION:
+        - edx.devstack.memcached:11211
+        TIMEOUT: 300
+    staticfiles:
+        BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
+            connect_timeout: 0.5
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
+        KEY_PREFIX: 78f87108afce_general
+        LOCATION:
+        - edx.devstack.memcached:11211
+CAS_ATTRIBUTE_CALLBACK: ''
+CAS_EXTRA_LOGIN_PARAMS: ''
+CAS_SERVER_URL: ''
+CELERYBEAT_SCHEDULER: celery.beat:PersistentScheduler
+CELERY_BROKER_HOSTNAME: localhost
+CELERY_BROKER_PASSWORD: ''
+CELERY_BROKER_TRANSPORT: redis
+CELERY_BROKER_USER: ''
+CELERY_BROKER_USE_SSL: false
+CELERY_BROKER_VHOST: ''
+CELERY_EVENT_QUEUE_TTL: null
+CELERY_QUEUES:
+- edx.cms.core.default
+- edx.cms.core.high
+CELERY_TIMEZONE: UTC
+CERTIFICATE_TEMPLATE_LANGUAGES:
+    en: English
+    es: Español
+CERT_QUEUE: certificates
+CMS_BASE: edx.devstack.studio:18010
+CODE_JAIL:
+    limits:
+        CPU: 1
+        FSIZE: 1048576
+        PROXY: 0
+        REALTIME: 3
+        VMEM: 536870912
+    python_bin: /edx/app/edxapp/venvs/edxapp-sandbox/bin/python
+    user: sandbox
+COMMENTS_SERVICE_KEY: password
+COMMENTS_SERVICE_URL: http://localhost:18080
+COMPREHENSIVE_THEME_DIRS:
+- ''
+COMPREHENSIVE_THEME_LOCALE_PATHS: []
+CONTACT_EMAIL: info@example.com
+CONTENTSTORE:
+    ADDITIONAL_OPTIONS: {}
+    DOC_STORE_CONFIG:
+        authsource: ''
+        collection: modulestore
+        connectTimeoutMS: 2000
+        db: edxapp
+        host:
+        - edx.devstack.mongo
+        password: password
+        port: 27017
+        read_preference: PRIMARY
+        replicaSet: ''
+        socketTimeoutMS: 3000
+        ssl: false
+        user: edxapp
+    ENGINE: xmodule.contentstore.mongo.MongoContentStore
+    OPTIONS:
+        auth_source: ''
+        db: edxapp
+        host:
+        - edx.devstack.mongo
+        password: password
+        port: 27017
+        ssl: false
+        user: edxapp
+CORS_ORIGIN_ALLOW_ALL: false
+CORS_ORIGIN_WHITELIST: []
+COURSES_WITH_UNSAFE_CODE: []
+COURSE_ABOUT_VISIBILITY_PERMISSION: see_exists
+COURSE_AUTHORING_MICROFRONTEND_URL: null
+COURSE_CATALOG_API_URL: http://localhost:8008/api/v1
+COURSE_CATALOG_URL_ROOT: http://localhost:8008
+COURSE_CATALOG_VISIBILITY_PERMISSION: see_exists
+COURSE_IMPORT_EXPORT_BUCKET: ''
+CREDENTIALS_INTERNAL_SERVICE_URL: http://localhost:8005
+CREDENTIALS_PUBLIC_SERVICE_URL: http://localhost:8005
+CREDIT_PROVIDER_SECRET_KEYS: {}
+CROSS_DOMAIN_CSRF_COOKIE_DOMAIN: ''
+CROSS_DOMAIN_CSRF_COOKIE_NAME: ''
+CSRF_COOKIE_SECURE: false
+CSRF_TRUSTED_ORIGINS: []
+DASHBOARD_COURSE_LIMIT: null
+DATABASES:
+    default:
+        ATOMIC_REQUESTS: true
+        CONN_MAX_AGE: 0
+        ENGINE: django.db.backends.mysql
+        HOST: edx.devstack.mysql80
+        NAME: edxapp
+        OPTIONS:
+            isolation_level: read committed
+        PASSWORD: password
+        PORT: '3306'
+        USER: edxapp001
+    read_replica:
+        CONN_MAX_AGE: 0
+        ENGINE: django.db.backends.mysql
+        HOST: edx.devstack.mysql80
+        NAME: edxapp
+        OPTIONS:
+            isolation_level: read committed
+        PASSWORD: password
+        PORT: '3306'
+        USER: edxapp001
+    student_module_history:
+        CONN_MAX_AGE: 0
+        ENGINE: django.db.backends.mysql
+        HOST: edx.devstack.mysql80
+        NAME: edxapp_csmh
+        OPTIONS:
+            isolation_level: read committed
+        PASSWORD: password
+        PORT: '3306'
+        USER: edxapp001
+DATA_DIR: /edx/var/edxapp
+DEFAULT_COURSE_VISIBILITY_IN_CATALOG: both
+DEFAULT_FEEDBACK_EMAIL: feedback@example.com
+DEFAULT_FILE_STORAGE: django.core.files.storage.FileSystemStorage
+DEFAULT_FROM_EMAIL: registration@example.com
+DEFAULT_JWT_ISSUER:
+    AUDIENCE: lms-key
+    ISSUER: http://edx.devstack.lms:18000/oauth2
+    SECRET_KEY: lms-secret
+DEFAULT_MOBILE_AVAILABLE: false
+DEFAULT_SITE_THEME: ''
+DEPRECATED_ADVANCED_COMPONENT_TYPES: []
+DJFS:
+    directory_root: /edx/var/edxapp/django-pyfs/static/django-pyfs
+    type: osfs
+    url_root: /static/django-pyfs
+DOC_STORE_CONFIG:
+    authsource: ''
+    collection: modulestore
+    connectTimeoutMS: 2000
+    db: edxapp
+    host:
+    - edx.devstack.mongo
+    password: password
+    port: 27017
+    read_preference: PRIMARY
+    replicaSet: ''
+    socketTimeoutMS: 3000
+    ssl: false
+    user: edxapp
+ECOMMERCE_API_SIGNING_KEY: lms-secret
+ECOMMERCE_API_URL: http://localhost:8002/api/v2
+ECOMMERCE_PUBLIC_URL_ROOT: http://localhost:8002
+EDXMKTG_USER_INFO_COOKIE_NAME: edx-user-info
+EDX_PLATFORM_REVISION: master
+ELASTIC_SEARCH_CONFIG:
+-   host: edx.devstack.elasticsearch
+    port: 9200
+    use_ssl: false
+EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
+EMAIL_HOST: localhost
+EMAIL_HOST_PASSWORD: ''
+EMAIL_HOST_USER: ''
+EMAIL_PORT: 25
+EMAIL_USE_TLS: false
+ENABLE_COMPREHENSIVE_THEMING: false
+ENTERPRISE_API_URL: http://edx.devstack.lms:18000/enterprise/api/v1
+ENTERPRISE_MARKETING_FOOTER_QUERY_PARAMS: {}
+ENTERPRISE_SERVICE_WORKER_USERNAME: enterprise_worker
+EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST: []
+EXAMS_API_URL: http://localhost:8740/api/v1
+EXTRA_MIDDLEWARE_CLASSES: []
+FACEBOOK_API_VERSION: v2.1
+FACEBOOK_APP_ID: FACEBOOK_APP_ID
+FACEBOOK_APP_SECRET: FACEBOOK_APP_SECRET
+FEATURES:
+    AUTH_USE_OPENID_PROVIDER: true
+    AUTOMATIC_AUTH_FOR_TESTING: false
+    CUSTOM_COURSES_EDX: false
+    ENABLE_BULK_ENROLLMENT_VIEW: false
+    ENABLE_COMBINED_LOGIN_REGISTRATION: true
+    ENABLE_CORS_HEADERS: false
+    ENABLE_COUNTRY_ACCESS: false
+    ENABLE_CREDIT_API: false
+    ENABLE_CREDIT_ELIGIBILITY: false
+    ENABLE_CROSS_DOMAIN_CSRF_COOKIE: false
+    ENABLE_CSMH_EXTENDED: true
+    ENABLE_DISCUSSION_HOME_PANEL: true
+    ENABLE_DISCUSSION_SERVICE: true
+    ENABLE_EDXNOTES: true
+    ENABLE_ENROLLMENT_RESET: false
+    ENABLE_EXPORT_GIT: false
+    ENABLE_GRADE_DOWNLOADS: true
+    ENABLE_LTI_PROVIDER: false
+    ENABLE_MKTG_SITE: false
+    ENABLE_MOBILE_REST_API: false
+    ENABLE_OAUTH2_PROVIDER: false
+    ENABLE_PUBLISHER: false
+    ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES: true
+    ENABLE_SPECIAL_EXAMS: false
+    ENABLE_SYSADMIN_DASHBOARD: false
+    ENABLE_THIRD_PARTY_AUTH: true
+    ENABLE_VIDEO_UPLOAD_PIPELINE: false
+    SHOW_FOOTER_LANGUAGE_SELECTOR: false
+    SHOW_HEADER_LANGUAGE_SELECTOR: false
+FEEDBACK_SUBMISSION_EMAIL: ''
+FERNET_KEYS:
+- DUMMY KEY CHANGE BEFORE GOING TO PRODUCTION
+FILE_UPLOAD_STORAGE_BUCKET_NAME: SET-ME-PLEASE (ex. bucket-name)
+FILE_UPLOAD_STORAGE_PREFIX: submissions_attachments
+FINANCIAL_REPORTS:
+    BUCKET: null
+    ROOT_PATH: sandbox
+    STORAGE_TYPE: localfs
+GITHUB_REPO_ROOT: /edx/var/edxapp/data
+GIT_REPO_EXPORT_DIR: /edx/var/edxapp/export_course_repos
+GOOGLE_ANALYTICS_ACCOUNT: null
+GRADES_DOWNLOAD:
+    BUCKET: ''
+    ROOT_PATH: ''
+    STORAGE_CLASS: django.core.files.storage.FileSystemStorage
+    STORAGE_KWARGS:
+        location: /tmp/edx-s3/grades
+    STORAGE_TYPE: ''
+HELP_TOKENS_BOOKS:
+    course_author: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course
+    learner: http://edx.readthedocs.io/projects/open-edx-learner-guide
+ICP_LICENSE: null
+ICP_LICENSE_INFO: {}
+IDA_LOGOUT_URI_LIST: []
+ID_VERIFICATION_SUPPORT_LINK: ''
+INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT:
+    SAP: 1
+JWT_AUTH:
+    JWT_AUDIENCE: lms-key
+    JWT_AUTH_COOKIE_HEADER_PAYLOAD: edx-jwt-cookie-header-payload
+    JWT_AUTH_COOKIE_SIGNATURE: edx-jwt-cookie-signature
+    JWT_ISSUER: http://edx.devstack.lms:18000/oauth2
+    JWT_ISSUERS:
+    -   AUDIENCE: lms-key
+        ISSUER: http://edx.devstack.lms:18000/oauth2
+        SECRET_KEY: lms-secret
+    JWT_PUBLIC_SIGNING_JWK_SET: ''
+    JWT_SECRET_KEY: lms-secret
+    JWT_SIGNING_ALGORITHM: null
+JWT_EXPIRATION: 30
+JWT_ISSUER: http://edx.devstack.lms:18000/oauth2
+JWT_PRIVATE_SIGNING_KEY: null
+LANGUAGE_CODE: en
+LANGUAGE_COOKIE: openedx-language-preference
+LEARNER_PORTAL_URL_ROOT: https://learner-portal-edx.devstack.lms:18000
+LMS_BASE: edx.devstack.lms:18000
+LMS_INTERNAL_ROOT_URL: http://edx.devstack.lms:18000
+LMS_ROOT_URL: http://edx.devstack.lms:18000
+LOCAL_LOGLEVEL: INFO
+LOGGING_ENV: sandbox
+LOGIN_REDIRECT_WHITELIST: []
+LOG_DIR: /edx/var/log/edx
+MAINTENANCE_BANNER_TEXT: Sample banner message
+MEDIA_ROOT: /edx/var/edxapp/media/
+MEDIA_URL: /media/
+MKTG_URLS: {}
+MKTG_URL_LINK_MAP: {}
+MOBILE_STORE_ACE_URLS: {}
+MODULESTORE:
+    default:
+        ENGINE: xmodule.modulestore.mixed.MixedModuleStore
+        OPTIONS:
+            mappings: {}
+            stores:
+            -   DOC_STORE_CONFIG:
+                    authsource: ''
+                    collection: modulestore
+                    connectTimeoutMS: 2000
+                    db: edxapp
+                    host:
+                    - edx.devstack.mongo
+                    password: password
+                    port: 27017
+                    read_preference: PRIMARY
+                    replicaSet: ''
+                    socketTimeoutMS: 3000
+                    ssl: false
+                    user: edxapp
+                ENGINE: xmodule.modulestore.split_mongo.split_draft.DraftVersioningModuleStore
+                NAME: split
+                OPTIONS:
+                    default_class: xmodule.hidden_block.HiddenBlock
+                    fs_root: /edx/var/edxapp/data
+                    render_template: common.djangoapps.edxmako.shortcuts.render_to_string
+            -   DOC_STORE_CONFIG:
+                    authsource: ''
+                    collection: modulestore
+                    connectTimeoutMS: 2000
+                    db: edxapp
+                    host:
+                    - edx.devstack.mongo
+                    password: password
+                    port: 27017
+                    read_preference: PRIMARY
+                    replicaSet: ''
+                    socketTimeoutMS: 3000
+                    ssl: false
+                    user: edxapp
+                ENGINE: xmodule.modulestore.mongo.DraftMongoModuleStore
+                NAME: draft
+                OPTIONS:
+                    default_class: xmodule.hidden_block.HiddenBlock
+                    fs_root: /edx/var/edxapp/data
+                    render_template: common.djangoapps.edxmako.shortcuts.render_to_string
+ORA2_FILE_PREFIX: default_env-default_deployment/ora2
+PARSE_KEYS: {}
+PARTNER_SUPPORT_EMAIL: ''
+PASSWORD_POLICY_COMPLIANCE_ROLLOUT_CONFIG:
+    ENFORCE_COMPLIANCE_ON_LOGIN: false
+PASSWORD_RESET_SUPPORT_LINK: ''
+PAYMENT_SUPPORT_EMAIL: billing@example.com
+PLATFORM_DESCRIPTION: Your Platform Description Here
+PLATFORM_FACEBOOK_ACCOUNT: http://www.facebook.com/YourPlatformFacebookAccount
+PLATFORM_NAME: Your Platform Name Here
+PLATFORM_TWITTER_ACCOUNT: '@YourPlatformTwitterAccount'
+POLICY_CHANGE_GRADES_ROUTING_KEY: edx.lms.core.default
+SINGLE_LEARNER_COURSE_REGRADE_ROUTING_KEY: edx.lms.core.default
+PREPEND_LOCALE_PATHS: []
+PRESS_EMAIL: press@example.com
+PROCTORING_BACKENDS:
+    DEFAULT: 'null'
+    'null': {}
+PROCTORING_SETTINGS: {}
+REGISTRATION_EXTRA_FIELDS:
+    city: hidden
+    confirm_email: hidden
+    country: required
+    gender: optional
+    goals: optional
+    honor_code: required
+    level_of_education: optional
+    mailing_address: hidden
+    terms_of_service: hidden
+    year_of_birth: optional
+RETIRED_EMAIL_DOMAIN: retired.invalid
+RETIRED_EMAIL_PREFIX: retired__user_
+RETIRED_USERNAME_PREFIX: retired__user_
+RETIRED_USER_SALTS:
+- OVERRIDE ME WITH A RANDOM VALUE
+- ROTATE SALTS BY APPENDING NEW VALUES
+RETIREMENT_SERVICE_WORKER_USERNAME: retirement_worker
+RETIREMENT_STATES:
+- PENDING
+- ERRORED
+- ABORTED
+- COMPLETE
+SECRET_KEY: DUMMY KEY ONLY FOR TO DEVSTACK
+SEGMENT_KEY: null
+SERVER_EMAIL: sre@example.com
+SESSION_COOKIE_DOMAIN: ''
+SESSION_COOKIE_NAME: sessionid
+SESSION_COOKIE_SECURE: false
+SESSION_SAVE_EVERY_REQUEST: false
+SITE_NAME: localhost
+SOCIAL_AUTH_SAML_SP_PRIVATE_KEY: ''
+SOCIAL_AUTH_SAML_SP_PRIVATE_KEY_DICT: {}
+SOCIAL_AUTH_SAML_SP_PUBLIC_CERT: ''
+SOCIAL_AUTH_SAML_SP_PUBLIC_CERT_DICT: {}
+SOCIAL_MEDIA_FOOTER_URLS: {}
+SOCIAL_SHARING_SETTINGS:
+    CERTIFICATE_FACEBOOK: false
+    CERTIFICATE_TWITTER: false
+    CUSTOM_COURSE_URLS: false
+    DASHBOARD_FACEBOOK: false
+    DASHBOARD_TWITTER: false
+STATIC_ROOT_BASE: /edx/var/edxapp/staticfiles
+STATIC_URL_BASE: /static/
+STUDIO_NAME: Studio
+STUDIO_SHORT_NAME: Studio
+SUPPORT_SITE_LINK: ''
+SWIFT_AUTH_URL: null
+SWIFT_AUTH_VERSION: null
+SWIFT_KEY: null
+SWIFT_REGION_NAME: null
+SWIFT_TEMP_URL_DURATION: 1800
+SWIFT_TEMP_URL_KEY: null
+SWIFT_TENANT_ID: null
+SWIFT_TENANT_NAME: null
+SWIFT_USERNAME: null
+SWIFT_USE_TEMP_URLS: false
+SYSLOG_SERVER: ''
+SYSTEM_WIDE_ROLE_CLASSES: []
+TECH_SUPPORT_EMAIL: technical@example.com
+TIME_ZONE: America/New_York
+UNIVERSITY_EMAIL: university@example.com
+USERNAME_REPLACEMENT_WORKER: OVERRIDE THIS WITH A VALID USERNAME
+VIDEO_IMAGE_MAX_AGE: 31536000
+VIDEO_IMAGE_SETTINGS:
+    DIRECTORY_PREFIX: video-images/
+    STORAGE_KWARGS:
+        location: /edx/var/edxapp/media/
+    VIDEO_IMAGE_MAX_BYTES: 2097152
+    VIDEO_IMAGE_MIN_BYTES: 2048
+    BASE_URL: /media/
+VIDEO_TRANSCRIPTS_MAX_AGE: 31536000
+VIDEO_TRANSCRIPTS_SETTINGS:
+    DIRECTORY_PREFIX: video-transcripts/
+    STORAGE_KWARGS:
+        location: /edx/var/edxapp/media/
+    VIDEO_TRANSCRIPTS_MAX_BYTES: 3145728
+    BASE_URL: /media/
+VIDEO_UPLOAD_PIPELINE:
+    BUCKET: ''
+    ROOT_PATH: ''
+WIKI_ENABLED: true
+XBLOCK_FS_STORAGE_BUCKET: null
+XBLOCK_FS_STORAGE_PREFIX: null
+XBLOCK_SETTINGS: {}
+XQUEUE_INTERFACE:
+    basic_auth:
+    - edx
+    - edx
+    django_auth:
+        password: password
+        username: lms
+    url: http://edx.devstack.xqueue:18040
+X_FRAME_OPTIONS: DENY
+YOUTUBE_API_KEY: PUT_YOUR_API_KEY_HERE
+ZENDESK_API_KEY: ''
+ZENDESK_CUSTOM_FIELDS: {}
+ZENDESK_GROUP_ID_MAPPING: {}
+ZENDESK_OAUTH_ACCESS_TOKEN: ''
+ZENDESK_URL: ''
+ZENDESK_USER: ''

--- a/configuration_files/lms.yml
+++ b/configuration_files/lms.yml
@@ -1,0 +1,655 @@
+# This file is an experimental extraction of /edx/etc/lms.yml from
+# a LMS devstack container.
+#
+# When devstack is configured to use the new `openedx/` images
+# instead of the old `edxops/edxapp` image, it will use this file
+# as input to lms/envs/production.py (and, in turn, lms/envs/devstack.py).
+# If you are using devstack with the `edxops/edxapp` image, though,
+# this file is NOT used.
+#
+# Q. Should I update this file when I update devstack.py?
+# A. You don't *have* to, because settings in devstack.py
+#    override these settings. But, it doesn't harm to also make them
+#    here in order to quell confusion. The hope is that we'll
+#    adopt OEP-45 eventually, which recommends against having
+#    a devstack.py at all.
+#
+# This is part of the effort to move our dev tools off of Ansible and
+# Paver, described here: https://github.com/openedx/devstack/pull/866
+# TODO: If the effort described above is abandoned, then this file should
+# probably be deleted.
+ACCOUNT_MICROFRONTEND_URL: null
+ACE_CHANNEL_DEFAULT_EMAIL: django_email
+ACE_CHANNEL_SAILTHRU_API_KEY: ''
+ACE_CHANNEL_SAILTHRU_API_SECRET: ''
+ACE_CHANNEL_SAILTHRU_DEBUG: true
+ACE_CHANNEL_SAILTHRU_TEMPLATE_NAME: null
+ACE_CHANNEL_TRANSACTIONAL_EMAIL: django_email
+ACE_ENABLED_CHANNELS:
+- django_email
+ACE_ENABLED_POLICIES:
+- bulk_email_optout
+ACE_ROUTING_KEY: edx.lms.core.default
+ACTIVATION_EMAIL_SUPPORT_LINK: ''
+AFFILIATE_COOKIE_NAME: dev_affiliate_id
+ALTERNATE_WORKER_QUEUES: cms
+ANALYTICS_API_KEY: ''
+ANALYTICS_API_URL: http://localhost:18100
+ANALYTICS_DASHBOARD_NAME: Your Platform Name Here Insights
+ANALYTICS_DASHBOARD_URL: http://localhost:18110/courses
+API_ACCESS_FROM_EMAIL: api-requests@example.com
+API_ACCESS_MANAGER_EMAIL: api-access@example.com
+API_DOCUMENTATION_URL: http://course-catalog-api-guide.readthedocs.io/en/latest/
+AUTH_DOCUMENTATION_URL: http://course-catalog-api-guide.readthedocs.io/en/latest/authentication/index.html
+AUTH_PASSWORD_VALIDATORS:
+-   NAME: django.contrib.auth.password_validation.UserAttributeSimilarityValidator
+-   NAME: common.djangoapps.util.password_policy_validators.MinimumLengthValidator
+    OPTIONS:
+        min_length: 2
+-   NAME: common.djangoapps.util.password_policy_validators.MaximumLengthValidator
+    OPTIONS:
+        max_length: 75
+AWS_ACCESS_KEY_ID: null
+AWS_QUERYSTRING_AUTH: false
+AWS_S3_CUSTOM_DOMAIN: SET-ME-PLEASE (ex. bucket-name.s3.amazonaws.com)
+AWS_SECRET_ACCESS_KEY: null
+AWS_SES_REGION_ENDPOINT: email.us-east-1.amazonaws.com
+AWS_SES_REGION_NAME: us-east-1
+AWS_STORAGE_BUCKET_NAME: SET-ME-PLEASE (ex. bucket-name)
+BASE_COOKIE_DOMAIN: localhost
+BLOCK_STRUCTURES_SETTINGS:
+    COURSE_PUBLISH_TASK_DELAY: 30
+    TASK_DEFAULT_RETRY_DELAY: 30
+    TASK_MAX_RETRIES: 5
+BRANCH_IO_KEY: ''
+BUGS_EMAIL: bugs@example.com
+BULK_EMAIL_DEFAULT_FROM_EMAIL: no-reply@example.com
+BULK_EMAIL_EMAILS_PER_TASK: 500
+BULK_EMAIL_LOG_SENT_EMAILS: false
+BULK_EMAIL_ROUTING_KEY_SMALL_JOBS: edx.lms.core.default
+CACHES:
+    celery:
+        BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
+            connect_timeout: 0.5
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
+        KEY_PREFIX: celery
+        LOCATION:
+        - edx.devstack.memcached:11211
+        TIMEOUT: '7200'
+    configuration:
+        BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
+            connect_timeout: 0.5
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
+        KEY_PREFIX: 78f87108afce
+        LOCATION:
+        - edx.devstack.memcached:11211
+    course_structure_cache:
+        BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
+            connect_timeout: 0.5
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
+        KEY_PREFIX: course_structure
+        LOCATION:
+        - edx.devstack.memcached:11211
+        TIMEOUT: '604800'
+    default:
+        BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
+            connect_timeout: 0.5
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
+        KEY_PREFIX: default
+        LOCATION:
+        - edx.devstack.memcached:11211
+        VERSION: '1'
+    general:
+        BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
+            connect_timeout: 0.5
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
+        KEY_PREFIX: general
+        LOCATION:
+        - edx.devstack.memcached:11211
+    mongo_metadata_inheritance:
+        BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
+            connect_timeout: 0.5
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
+        KEY_PREFIX: mongo_metadata_inheritance
+        LOCATION:
+        - edx.devstack.memcached:11211
+        TIMEOUT: 300
+    staticfiles:
+        BACKEND: django.core.cache.backends.memcached.PyMemcacheCache
+        OPTIONS:
+            no_delay: true
+            ignore_exc: true
+            use_pooling: true
+            connect_timeout: 0.5
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
+        KEY_PREFIX: 78f87108afce_general
+        LOCATION:
+        - edx.devstack.memcached:11211
+CAS_ATTRIBUTE_CALLBACK: ''
+CAS_EXTRA_LOGIN_PARAMS: ''
+CAS_SERVER_URL: ''
+CELERYBEAT_SCHEDULER: celery.beat:PersistentScheduler
+CELERY_BROKER_HOSTNAME: localhost
+CELERY_BROKER_PASSWORD: ''
+CELERY_BROKER_TRANSPORT: redis
+CELERY_BROKER_USER: ''
+CELERY_BROKER_USE_SSL: false
+CELERY_BROKER_VHOST: ''
+CELERY_EVENT_QUEUE_TTL: null
+CELERY_QUEUES:
+- edx.lms.core.default
+- edx.lms.core.high
+- edx.lms.core.high_mem
+CELERY_TIMEZONE: UTC
+CERTIFICATE_TEMPLATE_LANGUAGES:
+    en: English
+    es: Español
+CERT_QUEUE: certificates
+CMS_BASE: edx.devstack.studio:18010
+CODE_JAIL:
+    limits:
+        CPU: 1
+        FSIZE: 1048576
+        PROXY: 0
+        REALTIME: 3
+        VMEM: 536870912
+    python_bin: /edx/app/edxapp/venvs/edxapp-sandbox/bin/python
+    user: sandbox
+COMMENTS_SERVICE_KEY: password
+COMMENTS_SERVICE_URL: http://localhost:18080
+COMPREHENSIVE_THEME_DIRS:
+- ''
+COMPREHENSIVE_THEME_LOCALE_PATHS: []
+CONTACT_EMAIL: info@example.com
+CONTACT_MAILING_ADDRESS: SET-ME-PLEASE
+CONTENTSTORE:
+    ADDITIONAL_OPTIONS: {}
+    DOC_STORE_CONFIG:
+        authsource: ''
+        collection: modulestore
+        connectTimeoutMS: 2000
+        db: edxapp
+        host:
+        - edx.devstack.mongo
+        password: password
+        port: 27017
+        read_preference: SECONDARY_PREFERRED
+        replicaSet: ''
+        socketTimeoutMS: 3000
+        ssl: false
+        user: edxapp
+    ENGINE: xmodule.contentstore.mongo.MongoContentStore
+    OPTIONS:
+        auth_source: ''
+        db: edxapp
+        host:
+        - edx.devstack.mongo
+        password: password
+        port: 27017
+        ssl: false
+        user: edxapp
+CORS_ORIGIN_ALLOW_ALL: false
+CORS_ORIGIN_WHITELIST: []
+COURSES_WITH_UNSAFE_CODE: []
+COURSE_ABOUT_VISIBILITY_PERMISSION: see_exists
+COURSE_CATALOG_API_URL: http://localhost:8008/api/v1
+COURSE_CATALOG_URL_ROOT: http://localhost:8008
+COURSE_CATALOG_VISIBILITY_PERMISSION: see_exists
+CREDENTIALS_INTERNAL_SERVICE_URL: http://localhost:8005
+CREDENTIALS_PUBLIC_SERVICE_URL: http://localhost:8005
+CREDIT_HELP_LINK_URL: ''
+CREDIT_PROVIDER_SECRET_KEYS: {}
+CROSS_DOMAIN_CSRF_COOKIE_DOMAIN: ''
+CROSS_DOMAIN_CSRF_COOKIE_NAME: ''
+CSRF_COOKIE_SECURE: false
+CSRF_TRUSTED_ORIGINS: []
+DASHBOARD_COURSE_LIMIT: null
+DATABASES:
+    default:
+        ATOMIC_REQUESTS: true
+        CONN_MAX_AGE: 0
+        ENGINE: django.db.backends.mysql
+        HOST: edx.devstack.mysql80
+        NAME: edxapp
+        OPTIONS:
+            isolation_level: read committed
+        PASSWORD: password
+        PORT: '3306'
+        USER: edxapp001
+    read_replica:
+        CONN_MAX_AGE: 0
+        ENGINE: django.db.backends.mysql
+        HOST: edx.devstack.mysql80
+        NAME: edxapp
+        OPTIONS:
+            isolation_level: read committed
+        PASSWORD: password
+        PORT: '3306'
+        USER: edxapp001
+    student_module_history:
+        CONN_MAX_AGE: 0
+        ENGINE: django.db.backends.mysql
+        HOST: edx.devstack.mysql80
+        NAME: edxapp_csmh
+        OPTIONS:
+            isolation_level: read committed
+        PASSWORD: password
+        PORT: '3306'
+        USER: edxapp001
+DATA_DIR: /edx/var/edxapp
+DCS_SESSION_COOKIE_SAMESITE: Lax
+DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL: true
+DEFAULT_COURSE_VISIBILITY_IN_CATALOG: both
+DEFAULT_FEEDBACK_EMAIL: feedback@example.com
+DEFAULT_FILE_STORAGE: django.core.files.storage.FileSystemStorage
+DEFAULT_FROM_EMAIL: registration@example.com
+DEFAULT_JWT_ISSUER:
+    AUDIENCE: lms-key
+    ISSUER: http://edx.devstack.lms:18000/oauth2
+    SECRET_KEY: lms-secret
+DEFAULT_MOBILE_AVAILABLE: false
+DEFAULT_SITE_THEME: ''
+DEPRECATED_ADVANCED_COMPONENT_TYPES: []
+DJFS:
+    directory_root: /edx/var/edxapp/django-pyfs/static/django-pyfs
+    type: osfs
+    url_root: /static/django-pyfs
+DOC_STORE_CONFIG:
+    authsource: ''
+    collection: modulestore
+    connectTimeoutMS: 2000
+    db: edxapp
+    host:
+    - edx.devstack.mongo
+    password: password
+    port: 27017
+    read_preference: SECONDARY_PREFERRED
+    replicaSet: ''
+    socketTimeoutMS: 3000
+    ssl: false
+    user: edxapp
+ECOMMERCE_API_SIGNING_KEY: lms-secret
+ECOMMERCE_API_URL: http://localhost:8002/api/v2
+ECOMMERCE_PUBLIC_URL_ROOT: http://localhost:8002
+EDXMKTG_USER_INFO_COOKIE_NAME: edx-user-info
+EDXNOTES_INTERNAL_API: http://edx.devstack.edx_notes_api:18120/api/v1
+EDXNOTES_PUBLIC_API: http://localhost:18120/api/v1
+EDX_API_KEY: PUT_YOUR_API_KEY_HERE
+EDX_PLATFORM_REVISION: master
+ELASTIC_SEARCH_CONFIG:
+-   host: edx.devstack.elasticsearch
+    port: 9200
+    use_ssl: false
+EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
+EMAIL_HOST: localhost
+EMAIL_HOST_PASSWORD: ''
+EMAIL_HOST_USER: ''
+EMAIL_PORT: 25
+EMAIL_USE_TLS: false
+ENABLE_COMPREHENSIVE_THEMING: false
+ENTERPRISE_API_URL: http://edx.devstack.lms:18000/enterprise/api/v1
+ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES:
+- audit
+- honor
+ENTERPRISE_CUSTOMER_SUCCESS_EMAIL: customersuccess@edx.org
+ENTERPRISE_ENROLLMENT_API_URL: http://edx.devstack.lms:18000/api/enrollment/v1/
+ENTERPRISE_INTEGRATIONS_EMAIL: enterprise-integrations@edx.org
+ENTERPRISE_MARKETING_FOOTER_QUERY_PARAMS: {}
+ENTERPRISE_SERVICE_WORKER_USERNAME: enterprise_worker
+ENTERPRISE_SUPPORT_URL: ''
+ENTERPRISE_TAGLINE: ''
+EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST: []
+EXTRA_MIDDLEWARE_CLASSES: []
+FACEBOOK_API_VERSION: v2.1
+FACEBOOK_APP_ID: FACEBOOK_APP_ID
+FACEBOOK_APP_SECRET: FACEBOOK_APP_SECRET
+FEATURES:
+    AUTH_USE_OPENID_PROVIDER: true
+    AUTOMATIC_AUTH_FOR_TESTING: false
+    CUSTOM_COURSES_EDX: false
+    ENABLE_BULK_ENROLLMENT_VIEW: false
+    ENABLE_COMBINED_LOGIN_REGISTRATION: true
+    ENABLE_CORS_HEADERS: false
+    ENABLE_COUNTRY_ACCESS: false
+    ENABLE_CREDIT_API: false
+    ENABLE_CREDIT_ELIGIBILITY: false
+    ENABLE_CROSS_DOMAIN_CSRF_COOKIE: false
+    ENABLE_CSMH_EXTENDED: true
+    ENABLE_DISCUSSION_HOME_PANEL: true
+    ENABLE_DISCUSSION_SERVICE: true
+    ENABLE_EDXNOTES: true
+    ENABLE_ENROLLMENT_RESET: false
+    ENABLE_EXPORT_GIT: false
+    ENABLE_GRADE_DOWNLOADS: true
+    ENABLE_LTI_PROVIDER: false
+    ENABLE_MKTG_SITE: false
+    ENABLE_MOBILE_REST_API: false
+    ENABLE_OAUTH2_PROVIDER: false
+    ENABLE_PUBLISHER: false
+    ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES: true
+    ENABLE_SPECIAL_EXAMS: false
+    ENABLE_SYSADMIN_DASHBOARD: false
+    ENABLE_THIRD_PARTY_AUTH: true
+    ENABLE_VIDEO_UPLOAD_PIPELINE: false
+    SHOW_FOOTER_LANGUAGE_SELECTOR: false
+    SHOW_HEADER_LANGUAGE_SELECTOR: false
+FEEDBACK_SUBMISSION_EMAIL: ''
+FERNET_KEYS:
+- DUMMY KEY CHANGE BEFORE GOING TO PRODUCTION
+FILE_UPLOAD_STORAGE_BUCKET_NAME: SET-ME-PLEASE (ex. bucket-name)
+FILE_UPLOAD_STORAGE_PREFIX: submissions_attachments
+FINANCIAL_REPORTS:
+    BUCKET: null
+    ROOT_PATH: sandbox
+    STORAGE_TYPE: localfs
+GITHUB_REPO_ROOT: /edx/var/edxapp/data
+GIT_REPO_DIR: /edx/var/edxapp/course_repos
+GOOGLE_ANALYTICS_ACCOUNT: null
+GOOGLE_ANALYTICS_LINKEDIN: ''
+GOOGLE_ANALYTICS_TRACKING_ID: ''
+GOOGLE_SITE_VERIFICATION_ID: ''
+GRADES_DOWNLOAD:
+    BUCKET: ''
+    ROOT_PATH: ''
+    STORAGE_CLASS: django.core.files.storage.FileSystemStorage
+    STORAGE_KWARGS:
+        location: /tmp/edx-s3/grades
+    STORAGE_TYPE: ''
+HELP_TOKENS_BOOKS:
+    course_author: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course
+    learner: http://edx.readthedocs.io/projects/open-edx-learner-guide
+HTTPS: 'on'
+ICP_LICENSE: null
+ICP_LICENSE_INFO: {}
+IDA_LOGOUT_URI_LIST: []
+ID_VERIFICATION_SUPPORT_LINK: ''
+INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT:
+    SAP: 1
+JWT_AUTH:
+    JWT_AUDIENCE: lms-key
+    JWT_AUTH_COOKIE_HEADER_PAYLOAD: edx-jwt-cookie-header-payload
+    JWT_AUTH_COOKIE_SIGNATURE: edx-jwt-cookie-signature
+    JWT_ISSUER: http://edx.devstack.lms:18000/oauth2
+    JWT_ISSUERS:
+    -   AUDIENCE: lms-key
+        ISSUER: http://edx.devstack.lms:18000/oauth2
+        SECRET_KEY: lms-secret
+    JWT_PRIVATE_SIGNING_JWK: None
+    JWT_PUBLIC_SIGNING_JWK_SET: ''
+    JWT_SECRET_KEY: lms-secret
+    JWT_SIGNING_ALGORITHM: null
+JWT_EXPIRATION: 30
+JWT_ISSUER: http://edx.devstack.lms:18000/oauth2
+JWT_PRIVATE_SIGNING_KEY: null
+LANGUAGE_CODE: en
+LANGUAGE_COOKIE: openedx-language-preference
+LEARNER_PORTAL_URL_ROOT: https://learner-portal-edx.devstack.lms:18000
+LEARNING_MICROFRONTEND_URL: null
+LMS_BASE: edx.devstack.lms:18000
+LMS_INTERNAL_ROOT_URL: http://edx.devstack.lms:18000
+LMS_ROOT_URL: http://edx.devstack.lms:18000
+LOCAL_LOGLEVEL: INFO
+LOGGING_ENV: sandbox
+LOGIN_REDIRECT_WHITELIST: []
+LOG_DIR: /edx/var/log/edx
+LTI_AGGREGATE_SCORE_PASSBACK_DELAY: 900
+LTI_USER_EMAIL_DOMAIN: lti.example.com
+MAILCHIMP_NEW_USER_LIST_ID: null
+MAINTENANCE_BANNER_TEXT: Sample banner message
+MEDIA_ROOT: /edx/var/edxapp/media/
+MEDIA_URL: /media/
+MKTG_URLS: {}
+MKTG_URL_LINK_MAP: {}
+MOBILE_STORE_URLS: {}
+MODULESTORE:
+    default:
+        ENGINE: xmodule.modulestore.mixed.MixedModuleStore
+        OPTIONS:
+            mappings: {}
+            stores:
+            -   DOC_STORE_CONFIG:
+                    authsource: ''
+                    collection: modulestore
+                    connectTimeoutMS: 2000
+                    db: edxapp
+                    host:
+                    - edx.devstack.mongo
+                    password: password
+                    port: 27017
+                    read_preference: SECONDARY_PREFERRED
+                    replicaSet: ''
+                    socketTimeoutMS: 3000
+                    ssl: false
+                    user: edxapp
+                ENGINE: xmodule.modulestore.split_mongo.split_draft.DraftVersioningModuleStore
+                NAME: split
+                OPTIONS:
+                    default_class: xmodule.hidden_block.HiddenBlock
+                    fs_root: /edx/var/edxapp/data
+                    render_template: common.djangoapps.edxmako.shortcuts.render_to_string
+            -   DOC_STORE_CONFIG:
+                    authsource: ''
+                    collection: modulestore
+                    connectTimeoutMS: 2000
+                    db: edxapp
+                    host:
+                    - edx.devstack.mongo
+                    password: password
+                    port: 27017
+                    read_preference: PRIMARY
+                    replicaSet: ''
+                    socketTimeoutMS: 3000
+                    ssl: false
+                    user: edxapp
+                ENGINE: xmodule.modulestore.mongo.DraftMongoModuleStore
+                NAME: draft
+                OPTIONS:
+                    default_class: xmodule.hidden_block.HiddenBlock
+                    fs_root: /edx/var/edxapp/data
+                    render_template: common.djangoapps.edxmako.shortcuts.render_to_string
+OAUTH_DELETE_EXPIRED: true
+OAUTH_ENFORCE_SECURE: false
+OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DAYS: 365
+OAUTH_EXPIRE_PUBLIC_CLIENT_DAYS: 30
+OPTIMIZELY_PROJECT_ID: null
+ORA2_FILE_PREFIX: default_env-default_deployment/ora2
+ORDER_HISTORY_MICROFRONTEND_URL: null
+ORGANIZATIONS_AUTOCREATE: true
+PAID_COURSE_REGISTRATION_CURRENCY:
+- usd
+- $
+PARENTAL_CONSENT_AGE_LIMIT: 13
+PARTNER_SUPPORT_EMAIL: ''
+PASSWORD_POLICY_COMPLIANCE_ROLLOUT_CONFIG:
+    ENFORCE_COMPLIANCE_ON_LOGIN: false
+PASSWORD_RESET_SUPPORT_LINK: ''
+PAYMENT_SUPPORT_EMAIL: billing@example.com
+PDF_RECEIPT_BILLING_ADDRESS: 'Enter your receipt billing
+
+    address here.
+
+    '
+PDF_RECEIPT_COBRAND_LOGO_PATH: ''
+PDF_RECEIPT_DISCLAIMER_TEXT: 'ENTER YOUR RECEIPT DISCLAIMER TEXT HERE.
+
+    '
+PDF_RECEIPT_FOOTER_TEXT: 'Enter your receipt footer text here.
+
+    '
+PDF_RECEIPT_LOGO_PATH: ''
+PDF_RECEIPT_TAX_ID: 00-0000000
+PDF_RECEIPT_TAX_ID_LABEL: fake Tax ID
+PDF_RECEIPT_TERMS_AND_CONDITIONS: 'Enter your receipt terms and conditions here.
+
+    '
+PLATFORM_DESCRIPTION: Your Platform Description Here
+PLATFORM_FACEBOOK_ACCOUNT: http://www.facebook.com/YourPlatformFacebookAccount
+PLATFORM_NAME: Your Platform Name Here
+PLATFORM_TWITTER_ACCOUNT: '@YourPlatformTwitterAccount'
+POLICY_CHANGE_GRADES_ROUTING_KEY: edx.lms.core.default
+SINGLE_LEARNER_COURSE_REGRADE_ROUTING_KEY: edx.lms.core.default
+PREPEND_LOCALE_PATHS: []
+PRESS_EMAIL: press@example.com
+PROCTORING_BACKENDS:
+    DEFAULT: 'null'
+    'null': {}
+PROCTORING_SETTINGS: {}
+PROFILE_IMAGE_BACKEND:
+    class: openedx.core.storage.OverwriteStorage
+    options:
+        base_url: /media/profile-images/
+        location: /edx/var/edxapp/media/profile-images/
+PROFILE_IMAGE_HASH_SEED: placeholder_secret_key
+PROFILE_IMAGE_MAX_BYTES: 1048576
+PROFILE_IMAGE_MIN_BYTES: 100
+PROFILE_IMAGE_SIZES_MAP:
+    full: 500
+    large: 120
+    medium: 50
+    small: 30
+PROFILE_MICROFRONTEND_URL: null
+PROGRAM_CERTIFICATES_ROUTING_KEY: edx.lms.core.default
+PROGRAM_CONSOLE_MICROFRONTEND_URL: null
+RECALCULATE_GRADES_ROUTING_KEY: edx.lms.core.default
+REGISTRATION_EXTRA_FIELDS:
+    city: hidden
+    confirm_email: hidden
+    country: required
+    gender: optional
+    goals: optional
+    honor_code: required
+    level_of_education: optional
+    mailing_address: hidden
+    terms_of_service: hidden
+    year_of_birth: optional
+RETIRED_EMAIL_DOMAIN: retired.invalid
+RETIRED_EMAIL_PREFIX: retired__user_
+RETIRED_USERNAME_PREFIX: retired__user_
+RETIRED_USER_SALTS:
+- OVERRIDE ME WITH A RANDOM VALUE
+- ROTATE SALTS BY APPENDING NEW VALUES
+RETIREMENT_SERVICE_WORKER_USERNAME: retirement_worker
+RETIREMENT_STATES:
+- PENDING
+- ERRORED
+- ABORTED
+- COMPLETE
+SECRET_KEY: DUMMY KEY ONLY FOR TO DEVSTACK
+SEGMENT_KEY: null
+SERVER_EMAIL: sre@example.com
+SESSION_COOKIE_DOMAIN: ''
+SESSION_COOKIE_NAME: sessionid
+SESSION_COOKIE_SECURE: false
+SESSION_SAVE_EVERY_REQUEST: false
+SITE_NAME: localhost
+SOCIAL_AUTH_OAUTH_SECRETS: ''
+SOCIAL_AUTH_SAML_SP_PRIVATE_KEY: ''
+SOCIAL_AUTH_SAML_SP_PRIVATE_KEY_DICT: {}
+SOCIAL_AUTH_SAML_SP_PUBLIC_CERT: ''
+SOCIAL_AUTH_SAML_SP_PUBLIC_CERT_DICT: {}
+SOCIAL_MEDIA_FOOTER_URLS: {}
+SOCIAL_SHARING_SETTINGS:
+    CERTIFICATE_FACEBOOK: false
+    CERTIFICATE_TWITTER: false
+    CUSTOM_COURSE_URLS: false
+    DASHBOARD_FACEBOOK: false
+    DASHBOARD_TWITTER: false
+STATIC_ROOT_BASE: /edx/var/edxapp/staticfiles
+STATIC_URL_BASE: /static/
+STUDIO_NAME: Studio
+STUDIO_SHORT_NAME: Studio
+SUPPORT_SITE_LINK: ''
+SWIFT_AUTH_URL: null
+SWIFT_AUTH_VERSION: null
+SWIFT_KEY: null
+SWIFT_REGION_NAME: null
+SWIFT_TEMP_URL_DURATION: 1800
+SWIFT_TEMP_URL_KEY: null
+SWIFT_TENANT_ID: null
+SWIFT_TENANT_NAME: null
+SWIFT_USERNAME: null
+SWIFT_USE_TEMP_URLS: false
+SYSLOG_SERVER: ''
+SYSTEM_WIDE_ROLE_CLASSES: []
+TECH_SUPPORT_EMAIL: technical@example.com
+THIRD_PARTY_AUTH_BACKENDS:
+- social_core.backends.google.GoogleOAuth2
+- social_core.backends.linkedin.LinkedinOAuth2
+- social_core.backends.facebook.FacebookOAuth2
+- social_core.backends.azuread.AzureADOAuth2
+- common.djangoapps.third_party_auth.appleid.AppleIdAuth
+- common.djangoapps.third_party_auth.identityserver3.IdentityServer3
+- common.djangoapps.third_party_auth.saml.SAMLAuthBackend
+- common.djangoapps.third_party_auth.lti.LTIAuthBackend
+TIME_ZONE: America/New_York
+TRACKING_SEGMENTIO_WEBHOOK_SECRET: ''
+UNIVERSITY_EMAIL: university@example.com
+USERNAME_REPLACEMENT_WORKER: OVERRIDE THIS WITH A VALID USERNAME
+VERIFY_STUDENT:
+    DAYS_GOOD_FOR: 365
+    EXPIRING_SOON_WINDOW: 28
+VIDEO_CDN_URL:
+    EXAMPLE_COUNTRY_CODE: http://example.com/edx/video?s3_url=
+VIDEO_IMAGE_MAX_AGE: 31536000
+VIDEO_IMAGE_SETTINGS:
+    DIRECTORY_PREFIX: video-images/
+    STORAGE_KWARGS:
+        location: /edx/var/edxapp/media/
+    VIDEO_IMAGE_MAX_BYTES: 2097152
+    VIDEO_IMAGE_MIN_BYTES: 2048
+    BASE_URL: /media/
+VIDEO_TRANSCRIPTS_MAX_AGE: 31536000
+VIDEO_TRANSCRIPTS_SETTINGS:
+    DIRECTORY_PREFIX: video-transcripts/
+    STORAGE_KWARGS:
+        location: /edx/var/edxapp/media/
+    VIDEO_TRANSCRIPTS_MAX_BYTES: 3145728
+    BASE_URL: /media/
+VIDEO_UPLOAD_PIPELINE:
+    BUCKET: ''
+    ROOT_PATH: ''
+WIKI_ENABLED: true
+WRITABLE_GRADEBOOK_URL: null
+XBLOCK_FS_STORAGE_BUCKET: null
+XBLOCK_FS_STORAGE_PREFIX: null
+XBLOCK_SETTINGS: {}
+XQUEUE_INTERFACE:
+    basic_auth:
+    - edx
+    - edx
+    django_auth:
+        password: password
+        username: lms
+    url: http://edx.devstack.xqueue:18040
+X_FRAME_OPTIONS: DENY
+YOUTUBE_API_KEY: PUT_YOUR_API_KEY_HERE
+ZENDESK_API_KEY: ''
+ZENDESK_CUSTOM_FIELDS: {}
+ZENDESK_GROUP_ID_MAPPING: {}
+ZENDESK_OAUTH_ACCESS_TOKEN: ''
+ZENDESK_URL: ''
+ZENDESK_USER: ''

--- a/course-generator/create-courses.sh
+++ b/course-generator/create-courses.sh
@@ -42,7 +42,7 @@ done < "${@: -1}"
 
 if $cms ; then
 	echo "Creating courses on cms."
-	docker compose exec lms bash -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py cms --settings=devstack_docker generate_courses '$course_json'"
+	docker compose exec lms bash -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py cms --settings=devstack generate_courses '$course_json'"
 fi
 
 if $ecommerce ; then

--- a/credentials/generate_program_certificate.sh
+++ b/credentials/generate_program_certificate.sh
@@ -25,4 +25,4 @@ docker compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && python 
 echo 'generating course certificate'
 docker compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms cert_generation -u 3 -c course-v1:edX+DemoX+Demo_Course'
 echo 'notifying credentials'
-docker compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker notify_credentials --courses course-v1:edX+DemoX+Demo_Course --notify_programs'
+docker compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack notify_credentials --courses course-v1:edX+DemoX+Demo_Course --notify_programs'

--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -41,6 +41,8 @@ services:
       - edxapp_tox:/edx/app/edxapp/edx-platform/.tox
       - edxapp_uploads:/edx/var/edxapp/uploads
       - ${DEVSTACK_WORKSPACE}/src:/edx/src
+      - ${PWD}/configuration_files/cms.yml:/edx/etc/studio.yml
+      - ${PWD}/configuration_files/lms.yml:/edx/etc/lms.yml
       - ${PWD}/py_configuration_files/cms.py:/edx/app/edxapp/edx-platform/cms/envs/devstack.py
       - ${PWD}/py_configuration_files/lms.py:/edx/app/edxapp/edx-platform/lms/envs/devstack.py
       - ${PWD}/py_private_requirements/lms.txt:/edx/private_requirements.txt
@@ -72,6 +74,8 @@ services:
       - edxapp_tox:/edx/app/edxapp/edx-platform/.tox
       - edxapp_uploads:/edx/var/edxapp/uploads
       - ${DEVSTACK_WORKSPACE}/src:/edx/src
+      - ${PWD}/configuration_files/cms.yml:/edx/etc/studio.yml
+      - ${PWD}/configuration_files/lms.yml:/edx/etc/lms.yml
       - ${PWD}/py_configuration_files/cms.py:/edx/app/edxapp/edx-platform/cms/envs/devstack.py
       - ${PWD}/py_configuration_files/lms.py:/edx/app/edxapp/edx-platform/lms/envs/devstack.py
       - ${PWD}/py_private_requirements/cms.txt:/edx/private_requirements.txt

--- a/docs/devstack_faq.rst
+++ b/docs/devstack_faq.rst
@@ -231,19 +231,19 @@ How do I create new migrations?
 -------------------------------
 
 For LMS, log into the LMS shell and run the
-``makemigrations`` command with the ``devstack_docker`` settings:
+``makemigrations`` command with the ``devstack`` settings:
 
 .. code:: sh
 
    make dev.shell.lms
-   ./manage.py lms makemigrations <appname> --settings=devstack_docker
+   ./manage.py lms makemigrations <appname> --settings=devstack
 
 For CMS, it is similar:
 
 .. code:: sh
 
    make dev.shell.cms
-   ./manage.py cms makemigrations <appname> --settings=devstack_docker
+   ./manage.py cms makemigrations <appname> --settings=devstack
 
 Finally, for any other service, run:
 

--- a/docs/pycharm_integration.rst
+++ b/docs/pycharm_integration.rst
@@ -157,8 +157,8 @@ Configuration`_, with the following specific values.
 
 4. Environment variables, add the following for lms/cms:
 
-   - ``DJANGO_SETTINGS_MODULE=lms.envs.devstack_docker`` (or
-     cms.envs.devstack_docker)
+   - ``DJANGO_SETTINGS_MODULE=lms.envs.devstack`` (or
+     cms.envs.devstack)
    - ``PYTHONUNBUFFERED=1``
    - ``CONFIG_ROOT=/edx/app/edxapp``
    - ``LMS_CFG=/edx/etc/lms.yml``

--- a/docs/troubleshoot_general_tips.rst
+++ b/docs/troubleshoot_general_tips.rst
@@ -39,11 +39,11 @@ Running LMS commands within a container
 
 Most of the commands require a settings flag. If omitted, the flag defaults to
 ``devstack``. If you run into issues running commands in a docker container, you should append
-the ``devstack_docker`` flag. For example:
+the ``devstack`` flag. For example:
 
 .. code:: sh
 
-  $ npm run build && ./manage.py lms collectstatic --no-input --settings=devstack_docker
+  $ npm run build && ./manage.py lms collectstatic --no-input --settings=devstack
 
 Resource busy or locked
 -----------------------

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -20,7 +20,7 @@ These instructions are written using the LMS as an example. Replace ``lms`` with
 
           edx.devstack.lms                  | System check identified no issues (0 silenced).
           edx.devstack.lms                  | November 25, 2020 - 19:04:18
-          edx.devstack.lms                  | Django version 2.2.17, using settings 'lms.envs.devstack_docker'
+          edx.devstack.lms                  | Django version 2.2.17, using settings 'lms.envs.devstack'
           edx.devstack.lms                  | Starting development server at http://0.0.0.0:18000/
           edx.devstack.lms                  | Quit the server with CONTROL-C.
 

--- a/enterprise/provision.sh
+++ b/enterprise/provision.sh
@@ -2,7 +2,7 @@
 set -eu -o pipefail
 set -x
 
-docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker manage_user enterprise_worker enterprise_worker@example.com --staff'
-cat enterprise/worker_permissions.py | docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms shell --settings=devstack_docker'
+docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack manage_user enterprise_worker enterprise_worker@example.com --staff'
+cat enterprise/worker_permissions.py | docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms shell --settings=devstack'
 
-docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker create_dot_application --grant-type client-credentials --client-id "enterprise-backend-service-key" --client-secret "enterprise-backend-service-secret" enterprise-backend-service enterprise_worker'
+docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack create_dot_application --grant-type client-credentials --client-id "enterprise-backend-service-key" --client-secret "enterprise-backend-service-secret" enterprise-backend-service enterprise_worker'

--- a/provision-ida-user.sh
+++ b/provision-ida-user.sh
@@ -13,8 +13,8 @@ client_port=$3
 echo -e "${GREEN}Creating service user and OAuth2 applications for ${app_name}...${NC}"
 
 # Create the service user.
-docker compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker manage_user $1_worker $1_worker@example.com --staff --superuser' -- "$app_name"
+docker compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack manage_user $1_worker $1_worker@example.com --staff --superuser' -- "$app_name"
 
 # Create the DOT applications - one for single sign-on and one for backend service IDA-to-IDA authentication.
-docker compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker create_dot_application --grant-type authorization-code --skip-authorization --redirect-uris "http://localhost:$3/complete/edx-oauth2/" --client-id "$1-sso-key" --client-secret "$1-sso-secret" --scopes "user_id" $1-sso $1_worker' -- "$app_name" "$client_name" "$client_port"
-docker compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker create_dot_application --grant-type client-credentials --client-id "$1-backend-service-key" --client-secret "$1-backend-service-secret" $1-backend-service $1_worker' -- "$app_name" "$client_name" "$client_port"
+docker compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack create_dot_application --grant-type authorization-code --skip-authorization --redirect-uris "http://localhost:$3/complete/edx-oauth2/" --client-id "$1-sso-key" --client-secret "$1-sso-secret" --scopes "user_id" $1-sso $1_worker' -- "$app_name" "$client_name" "$client_port"
+docker compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack create_dot_application --grant-type client-credentials --client-id "$1-backend-service-key" --client-secret "$1-backend-service-secret" $1-backend-service $1_worker' -- "$app_name" "$client_name" "$client_port"

--- a/provision-lms.sh
+++ b/provision-lms.sh
@@ -29,24 +29,24 @@ done
 # Make migrate runs migrations for both lms and cms.
 docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && make migrate'
 
-docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms showmigrations --database student_module_history --traceback --pythonpath=. --settings devstack_docker'
-docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms migrate --database student_module_history --noinput --traceback --pythonpath=. --settings devstack_docker'
+docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms showmigrations --database student_module_history --traceback --pythonpath=. --settings devstack'
+docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms migrate --database student_module_history --noinput --traceback --pythonpath=. --settings devstack'
 
-docker compose exec -T cms bash -e -c 'source /edx/app/edxapp/edxapp_env && /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py cms showmigrations --database student_module_history --traceback --pythonpath=. --settings devstack_docker'
-docker compose exec -T cms bash -e -c 'source /edx/app/edxapp/edxapp_env && /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py cms migrate --database student_module_history --noinput --traceback --pythonpath=. --settings devstack_docker'
+docker compose exec -T cms bash -e -c 'source /edx/app/edxapp/edxapp_env && /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py cms showmigrations --database student_module_history --traceback --pythonpath=. --settings devstack'
+docker compose exec -T cms bash -e -c 'source /edx/app/edxapp/edxapp_env && /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py cms migrate --database student_module_history --noinput --traceback --pythonpath=. --settings devstack'
 
 # Create a superuser for edxapp
-docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker manage_user edx edx@example.com --superuser --staff'
-docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && echo "from django.contrib.auth import get_user_model; User = get_user_model(); user = User.objects.get(username=\"edx\"); user.set_password(\"edx\"); user.save()" | python /edx/app/edxapp/edx-platform/manage.py lms shell  --settings=devstack_docker'
+docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack manage_user edx edx@example.com --superuser --staff'
+docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && echo "from django.contrib.auth import get_user_model; User = get_user_model(); user = User.objects.get(username=\"edx\"); user.set_password(\"edx\"); user.save()" | python /edx/app/edxapp/edx-platform/manage.py lms shell  --settings=devstack'
 
 # Create an enterprise service user for edxapp and give them appropriate permissions
 ./enterprise/provision.sh
 
 # Enable the LMS-E-Commerce integration
-docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker configure_commerce'
+docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack configure_commerce'
 
 # Create demo course and users
-#docker compose exec -T lms bash -e -c '/edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook /edx/app/edx_ansible/edx_ansible/playbooks/demo.yml -v -c local -i "127.0.0.1," --extra-vars="COMMON_EDXAPP_SETTINGS=devstack_docker"'
+#docker compose exec -T lms bash -e -c '/edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook /edx/app/edx_ansible/edx_ansible/playbooks/demo.yml -v -c local -i "127.0.0.1," --extra-vars="COMMON_EDXAPP_SETTINGS=devstack"'
 if [[ ${DEVSTACK_SKIP_DEMO-false} == "true" ]]
 then
     echo "Skipping import of demo course. DEVSTACK_SKIP_DEMO is set to true"
@@ -54,7 +54,7 @@ else
     # FIXME: Using old version of demo course (open-release/quince.1) until we can
     # update devstack and other repos to match: https://github.com/openedx/devstack/issues/1273
     docker compose exec -T lms bash -e -c 'git clone https://github.com/openedx/edx-demo-course.git --branch open-release/quince.1 /tmp/edx-demo-course'
-    docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py cms --settings=devstack_docker import /edx/var/edxapp/data /tmp/edx-demo-course && rm -rf /tmp/edx-demo-course'
+    docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py cms --settings=devstack import /edx/var/edxapp/data /tmp/edx-demo-course && rm -rf /tmp/edx-demo-course'
 fi
 
 demo_hashed_password='pbkdf2_sha256$20000$TjE34FJjc3vv$0B7GUmH8RwrOc/BvMoxjb5j8EgnWTt3sxorDANeF7Qw='
@@ -62,14 +62,14 @@ for user in honor audit verified staff ; do
   email="$user@example.com"
   # Set staff flag for staff user
   if [[ $user == "staff" ]] ; then
-    docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker --service-variant lms manage_user $user $email --initial-password-hash '$demo_hashed_password' --staff"
+    docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack --service-variant lms manage_user $user $email --initial-password-hash '$demo_hashed_password' --staff"
   else
-    docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker --service-variant lms manage_user $user $email --initial-password-hash '$demo_hashed_password'"
+    docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack --service-variant lms manage_user $user $email --initial-password-hash '$demo_hashed_password'"
   fi
   if [[ "${DEVSTACK_SKIP_DEMO-false}" != "true" ]]
   then
   # Enroll users in the demo course
-      docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker --service-variant lms enroll_user_in_course -e $email -c course-v1:edX+DemoX+Demo_Course"
+      docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack --service-variant lms enroll_user_in_course -e $email -c course-v1:edX+DemoX+Demo_Course"
   fi
 done
 

--- a/provision-retirement-states.sh
+++ b/provision-retirement-states.sh
@@ -6,4 +6,4 @@ set -eu -o pipefail
 set -x
 
 echo -e "${GREEN}Creating retirement states...${NC}"
-docker compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker populate_retirement_states'
+docker compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack populate_retirement_states'

--- a/provision-retirement-user.sh
+++ b/provision-retirement-user.sh
@@ -9,5 +9,5 @@ app_name=$1
 user_name=$2
 
 echo -e "${GREEN}Creating retirement service user ${user_name} and DOT Application ${app_name}...${NC}"
-docker compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker manage_user $1 $1@example.com --staff --superuser' -- "$user_name"
-docker compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker create_dot_application $1 $2' -- "$app_name" "$user_name"
+docker compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack manage_user $1 $1@example.com --staff --superuser' -- "$user_name"
+docker compose exec -T lms  bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack create_dot_application $1 $2' -- "$app_name" "$user_name"


### PR DESCRIPTION
The devstack_docker settings file was removed from the edx-platform repository, and we had a bunch of references to it, including in the provisioning scripts.

The correct way to handle this is to use the devstack.py file, which is mounted in the host already.

This also adds in some devstack-specific cms.yml and lms.yml configuration files that then get mounted into the lms and cms containers. These are ported from the devstack-experimental.yml files that were previously in edx-platform and were removed. https://github.com/openedx/edx-platform/pull/36908

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
