### PR TITLE
chore: remove deprecated storage related settings

### DIFF
--- a/py_configuration_files/cms.py
+++ b/py_configuration_files/cms.py
@@ -9,7 +9,7 @@ from os.path import abspath, dirname, join
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 # Don't use S3 in devstack, fall back to filesystem
-del DEFAULT_FILE_STORAGE
+STORAGES['default']['BACKEND'] = 'django.core.files.storage.FileSystemStorage'
 COURSE_IMPORT_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'
 USER_TASKS_ARTIFACT_STORAGE = COURSE_IMPORT_EXPORT_STORAGE
 
@@ -57,7 +57,7 @@ FEATURES['ENABLE_VIDEO_UPLOAD_PIPELINE'] = True
 
 # Skip packaging and optimization in development
 PIPELINE['PIPELINE_ENABLED'] = False
-STATICFILES_STORAGE = 'openedx.core.storage.DevelopmentStorage'
+STORAGES['staticfiles']['BACKEND'] = 'openedx.core.storage.DevelopmentStorage'
 
 # Revert to the default set of finders as we don't want the production pipeline
 STATICFILES_FINDERS = [

--- a/py_configuration_files/lms.py
+++ b/py_configuration_files/lms.py
@@ -16,7 +16,7 @@ from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 # Don't use S3 in devstack, fall back to filesystem
-del DEFAULT_FILE_STORAGE
+STORAGES['default']['BACKEND'] = 'django.core.files.storage.FileSystemStorage'
 ORA2_FILEUPLOAD_BACKEND = 'django'
 
 
@@ -118,7 +118,7 @@ def should_show_debug_toolbar(request):  # lint-amnesty, pylint: disable=missing
 ########################### PIPELINE #################################
 
 PIPELINE['PIPELINE_ENABLED'] = False
-STATICFILES_STORAGE = 'openedx.core.storage.DevelopmentStorage'
+STORAGES['staticfiles']['BACKEND'] = 'openedx.core.storage.DevelopmentStorage'
 
 # Revert to the default set of finders as we don't want the production pipeline
 STATICFILES_FINDERS = [


### PR DESCRIPTION
# Description 
This PR refactors the code to replace the deprecated `DEFAULT_FILE_STORAGE` and `STATICFILES_STORAGE` settings with the more flexible and recommended `STORAGES = {}` pattern, a change that was recently done in [edx-platform#37002](https://github.com/openedx/edx-platform/pull/37002).

As devstack repo maintains it's own set of config files, the change is also required here.

## 2U Private Jira Link

- https://2u-internal.atlassian.net/browse/BOMS-214 
