### PR TITLE
chore: rename arbi-bom to orbi-bom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
     schedule:
         interval: "weekly"
     reviewers:
-      - "openedx/arbi-bom"
+      - "openedx/orbi-bom"

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -13,8 +13,8 @@ jobs:
    call-upgrade-python-requirements-workflow:
     with:
        branch: ${{ github.event.inputs.branch }}
-       team_reviewers: "arbi-bom"
-       email_address: arbi-bom@edx.org 
+       team_reviewers: "orbi-bom"
+       email_address: orbi-bom@edx.org 
        send_success_notification: false
     secrets:
        requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -14,8 +14,8 @@ jobs:
     with:
        branch: ${{ github.event.inputs.branch }}
        team_reviewers: "orbi-bom"
-       email_address: orbi-bom@edx.org 
-       send_success_notification: false
+       email_address: orbi-bom-upgrade-prs@2u-internal.jsmalerts.atlassian.net
+       send_success_notification: true
     secrets:
        requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
        requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}


### PR DESCRIPTION
Description

Update GitHub workflow failure email notifications to use [orbi-bom@edx.org](mailto:orbi-bom@edx.org) instead of [arbi-bom@edx.org](mailto:arbi-bom@edx.org) 
Updates team reviewer assignment in pull request creation from arbi-bom to orbi-bom 

Related PRs
https://github.com/edx/api-manager/pull/354
https://github.com/edx/edx-arch-experiments/pull/1107
https://github.com/edx/edx-internal/pull/13377
https://github.com/edx/repo-health-data/pull/312
https://github.com/edx/jenkins-job-dsl-internal/pull/962

Jira - [BOMS-39](https://2u-internal.atlassian.net/browse/BOMS-39)