### PR TITLE
feat: add FeaturesProxy integration for feature flag management in CMS and LMS

### DIFF
--- a/py_configuration_files/cms.py
+++ b/py_configuration_files/cms.py
@@ -8,6 +8,12 @@ from os.path import abspath, dirname, join
 
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
+try:
+    from openedx.core.lib.features_setting_proxy import FeaturesProxy
+    FEATURES = FeaturesProxy(globals())
+except ImportError:
+    pass
+
 # Don't use S3 in devstack, fall back to filesystem
 STORAGES['default']['BACKEND'] = 'django.core.files.storage.FileSystemStorage'
 COURSE_IMPORT_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'

--- a/py_configuration_files/lms.py
+++ b/py_configuration_files/lms.py
@@ -15,6 +15,12 @@ from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
 
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
+try:
+    from openedx.core.lib.features_setting_proxy import FeaturesProxy
+    FEATURES = FeaturesProxy(globals())
+except ImportError:
+    pass
+
 # Don't use S3 in devstack, fall back to filesystem
 STORAGES['default']['BACKEND'] = 'django.core.files.storage.FileSystemStorage'
 ORA2_FILEUPLOAD_BACKEND = 'django'


### PR DESCRIPTION
# Description
**Breaking change:**
Operators who maintain custom settings modules that write to `FEATURES` must add the following snippet at the top of their settings file(s) to ensure backwards compatibility:
``` 
try:
    from openedx.core.lib.features_setting_proxy import FeaturesProxy
    FEATURES = FeaturesProxy(globals())
except ImportError:
    pass 
```
This allows existing references to `FEATURES[...]` to continue functioning while Open edX transitions off of it.

### Reference:
- https://github.com/openedx/edx-platform/issues/37345

### 2U Private Jira Link : 
- [BOMS-200](https://2u-internal.atlassian.net/jira/software/c/projects/BOMS/boards/3017?assignee=712020%3Ad40977e4-f475-4263-b03e-f6b48134372b&selectedIssue=BOMS-200)