### PR TITLE
fix: corrects naming of make_mako_template_dirs function

### DIFF
--- a/docs/devstack_faq.rst
+++ b/docs/devstack_faq.rst
@@ -115,19 +115,19 @@ Make sure that you enable the following code in ./edx-platform/lms/envs/devstack
    # theme directories to COMPREHENSIVE_THEME_DIRS
 
    # We have to import the private method here because production.py calls
-   # derive_settings('lms.envs.production') which runs _make_mako_template_dirs with
+   # derive_settings('lms.envs.production') which runs make_mako_template_dirs with
    # the settings from production, which doesn't include these theming settings. Thus,
    # the templating engine is unable to find the themed templates because they don't exist
    # in it's path. Re-calling derive_settings doesn't work because the settings was already
    # changed from a function to a list, and it can't be derived again.
 
-   from .common import _make_mako_template_dirs
+   from .common import make_mako_template_dirs
    ENABLE_COMPREHENSIVE_THEMING = True
    COMPREHENSIVE_THEME_DIRS = [
        "/edx/app/edxapp/edx-platform/themes/",
        "/edx/app/edx-themes/edx-platform/",
    ]
-   TEMPLATES[1]["DIRS"] = Derived(_make_mako_template_dirs)
+   TEMPLATES[1]["DIRS"] = Derived(make_mako_template_dirs)
    derive_settings(__name__)
 
 Enabling a theme

--- a/provision-set-edx-theme.sh
+++ b/provision-set-edx-theme.sh
@@ -21,7 +21,7 @@ fi
 popd
 
 # Uncomment relevant lines in the devstack.py file
-sed -i '' "s|^# from .common import _make_mako_template_dirs|from .common import _make_mako_template_dirs|" "$DEVSTACK_FILE"
+sed -i '' "s|^# from .common import make_mako_template_dirs|from .common import make_mako_template_dirs|" "$DEVSTACK_FILE"
 sed -i '' "s|^# ENABLE_COMPREHENSIVE_THEMING = True|ENABLE_COMPREHENSIVE_THEMING = True|" "$DEVSTACK_FILE"
 sed -i '' "s|^# COMPREHENSIVE_THEME_DIRS = \[|COMPREHENSIVE_THEME_DIRS = \[|" "$DEVSTACK_FILE"
 sed -i '' "s|^#     \"/edx/app/edxapp/edx-platform/themes/\"|    \"/edx/app/edxapp/edx-platform/themes/\",|" "$DEVSTACK_FILE"
@@ -29,7 +29,7 @@ sed -i '' "/COMPREHENSIVE_THEME_DIRS = \[/a\\
 \"$THEME_DIR\",
 " "$DEVSTACK_FILE"
 sed -i '' "s|^# \]|]|" "$DEVSTACK_FILE"
-sed -i '' "s|^# TEMPLATES\[1\]\[\"DIRS\"\] = Derived(_make_mako_template_dirs)|TEMPLATES[1][\"DIRS\"] = Derived(_make_mako_template_dirs)|" "$DEVSTACK_FILE"
+sed -i '' "s|^# TEMPLATES\[1\]\[\"DIRS\"\] = Derived(make_mako_template_dirs)|TEMPLATES[1][\"DIRS\"] = Derived(make_mako_template_dirs)|" "$DEVSTACK_FILE"
 sed -i '' "s|^# derive_settings(__name__)|derive_settings(__name__)|" "$DEVSTACK_FILE"
 
 

--- a/py_configuration_files/lms.py
+++ b/py_configuration_files/lms.py
@@ -484,18 +484,19 @@ DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL = True
 # theme directories to COMPREHENSIVE_THEME_DIRS
 
 # We have to import the private method here because production.py calls
-# derive_settings('lms.envs.production') which runs _make_mako_template_dirs with
+# derive_settings('lms.envs.production') which runs make_mako_template_dirs with
 # the settings from production, which doesn't include these theming settings. Thus,
 # the templating engine is unable to find the themed templates because they don't exist
 # in it's path. Re-calling derive_settings doesn't work because the settings was already
 # changed from a function to a list, and it can't be derived again.
 
-# from .common import _make_mako_template_dirs
+# from .common import make_mako_template_dirs
 # ENABLE_COMPREHENSIVE_THEMING = True
 # COMPREHENSIVE_THEME_DIRS = [
+#     "/edx/src/edx-themes/edx-platform",
 #     "/edx/app/edxapp/edx-platform/themes/"
 # ]
-# TEMPLATES[1]["DIRS"] = Derived(_make_mako_template_dirs)
+# TEMPLATES[1]["DIRS"] = Derived(make_mako_template_dirs)
 # derive_settings(__name__)
 
 # Uncomment the lines below if you'd like to see SQL statements in your devstack LMS log.

--- a/py_configuration_files/lms.py
+++ b/py_configuration_files/lms.py
@@ -483,7 +483,7 @@ DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL = True
 # If you want to enable theming in devstack, uncomment this section and add any relevant
 # theme directories to COMPREHENSIVE_THEME_DIRS
 
-# We have to import the private method here because production.py calls
+# We have to import the function here because production.py calls
 # derive_settings('lms.envs.production') which runs make_mako_template_dirs with
 # the settings from production, which doesn't include these theming settings. Thus,
 # the templating engine is unable to find the themed templates because they don't exist


### PR DESCRIPTION
This function was renamed from `_make_mako_template_dirs` to `make_mako_template_dirs`.

This also inherits the addition of a local theming directory used for edx development.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
