### PR TITLE
fix: Django52 use STORAGES instead of DEFAULT_FILE_STORAGE and STATICFILES_STORAGE

### DIFF
--- a/configuration_files/cms.yml
+++ b/configuration_files/cms.yml
@@ -244,7 +244,6 @@ DATABASES:
 DATA_DIR: /edx/var/edxapp
 DEFAULT_COURSE_VISIBILITY_IN_CATALOG: both
 DEFAULT_FEEDBACK_EMAIL: feedback@example.com
-DEFAULT_FILE_STORAGE: django.core.files.storage.FileSystemStorage
 DEFAULT_FROM_EMAIL: registration@example.com
 DEFAULT_JWT_ISSUER:
     AUDIENCE: lms-key
@@ -494,6 +493,11 @@ SOCIAL_SHARING_SETTINGS:
     DASHBOARD_TWITTER: false
 STATIC_ROOT_BASE: /edx/var/edxapp/staticfiles
 STATIC_URL_BASE: /static/
+STORAGES:
+    default:
+        BACKEND: django.core.files.storage.FileSystemStorage
+    staticfiles:
+        BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
 STUDIO_NAME: Studio
 STUDIO_SHORT_NAME: Studio
 SUPPORT_SITE_LINK: ''

--- a/configuration_files/discovery.yml
+++ b/configuration_files/discovery.yml
@@ -69,7 +69,11 @@ JWT_AUTH:
     JWT_PUBLIC_SIGNING_JWK_SET: ''
 LANGUAGE_CODE: en
 MEDIA_STORAGE_BACKEND:
-    DEFAULT_FILE_STORAGE: django.core.files.storage.FileSystemStorage
+    STORAGES:
+        default:
+            BACKEND: django.core.files.storage.FileSystemStorage
+        staticfiles:
+            BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
     MEDIA_ROOT: /edx/var/discovery/media
     MEDIA_URL: /media/
 OPENEXCHANGERATES_API_KEY: ''
@@ -91,7 +95,11 @@ SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL: http://localhost:18000/logout
 SOCIAL_AUTH_EDX_OAUTH2_SECRET: discovery-sso-secret
 SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT: http://127.0.0.1:8000
 SOCIAL_AUTH_REDIRECT_IS_HTTPS: false
-STATICFILES_STORAGE: django.contrib.staticfiles.storage.StaticFilesStorage
 STATIC_ROOT: /edx/var/discovery/staticfiles
+STORAGES:
+    default:
+        BACKEND: django.core.files.storage.FileSystemStorage
+    staticfiles:
+        BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
 TIME_ZONE: UTC
 USERNAME_REPLACEMENT_WORKER: OVERRIDE THIS WITH A VALID USERNAME

--- a/configuration_files/lms.yml
+++ b/configuration_files/lms.yml
@@ -265,7 +265,6 @@ DCS_SESSION_COOKIE_SAMESITE: Lax
 DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL: true
 DEFAULT_COURSE_VISIBILITY_IN_CATALOG: both
 DEFAULT_FEEDBACK_EMAIL: feedback@example.com
-DEFAULT_FILE_STORAGE: django.core.files.storage.FileSystemStorage
 DEFAULT_FROM_EMAIL: registration@example.com
 DEFAULT_JWT_ISSUER:
     AUDIENCE: lms-key
@@ -580,6 +579,11 @@ SOCIAL_SHARING_SETTINGS:
     DASHBOARD_TWITTER: false
 STATIC_ROOT_BASE: /edx/var/edxapp/staticfiles
 STATIC_URL_BASE: /static/
+STORAGES:
+    default:
+        BACKEND: django.core.files.storage.FileSystemStorage
+    staticfiles:
+        BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
 STUDIO_NAME: Studio
 STUDIO_SHORT_NAME: Studio
 SUPPORT_SITE_LINK: ''

--- a/py_configuration_files/credentials.py
+++ b/py_configuration_files/credentials.py
@@ -42,10 +42,10 @@ INSTALLED_APPS += ["credentials.apps.edx_credentials_extensions"]
 EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
 EMAIL_FILE_PATH = "/tmp/credentials-emails"
 
-defaultfile_storage = os.environ.get("DEFAULT_FILE_STORAGE")
+default_file_storage = os.environ.get("DEFAULT_FILE_STORAGE")
 
-if defaultfile_storage:
-    STORAGES["default"]["BACKEND"] = defaultfile_storage
+if default_file_storage:
+    STORAGES["default"]["BACKEND"] = default_file_storage
 
 staticfiles_storage = os.environ.get("STATICFILES_STORAGE")
 

--- a/py_configuration_files/credentials.py
+++ b/py_configuration_files/credentials.py
@@ -42,10 +42,18 @@ INSTALLED_APPS += ["credentials.apps.edx_credentials_extensions"]
 EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
 EMAIL_FILE_PATH = "/tmp/credentials-emails"
 
-DEFAULT_FILE_STORAGE = os.environ.get("DEFAULT_FILE_STORAGE", "django.core.files.storage.FileSystemStorage")
+defaultfile_storage = os.environ.get("DEFAULT_FILE_STORAGE")
+
+if defaultfile_storage:
+    STORAGES["default"]["BACKEND"] = defaultfile_storage
+
+staticfiles_storage = os.environ.get("STATICFILES_STORAGE")
+
+if staticfiles_storage:
+    STORAGES["staticfiles"]["BACKEND"] = staticfiles_storage
+
 MEDIA_URL = os.environ.get("MEDIA_URL", "/media/")
 
-STATICFILES_STORAGE = os.environ.get("STATICFILES_STORAGE", "django.contrib.staticfiles.storage.StaticFilesStorage")
 STATIC_URL = os.environ.get("STATIC_URL", "/static/")
 
 # OAuth2 variables specific to social-auth/SSO login use case.


### PR DESCRIPTION
# Description 
This PR refactors the code to replace the deprecated `DEFAULT_FILE_STORAGE` and `STATICFILES_STORAGE` settings with the more flexible and recommended `STORAGES = {}` pattern, a change that was recently done in various repos in community.

For more details Refer to Jira links 

## 2U Private Jira Link
- https://2u-internal.atlassian.net/browse/BOMS-226
- https://2u-internal.atlassian.net/browse/BOMS-214
