### PR TITLE
fix: add 8-core minimum for codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,7 @@
 {
+    "hostRequirements": {
+        "cpus": 8
+    },
     "customizations": {
         "vscode": {
             "settings": {


### PR DESCRIPTION
- I've been told that a 4-core codespace isn't powerful enough to get started. 
- Our doc https://2u-internal.atlassian.net/wiki/spaces/ENG/pages/2003370007/Devstack+on+Codespaces+Guide recommends setting up with 8-core.

This change simply makes this the minimum requirement.

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
