### PR TITLE
fix: update pip version constraint to avoid compatibility issues with pip-tools

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,6 +13,6 @@
 
 # pip 25.3 is incompatible with pip-tools hence causing failures during the build process 
 # Make upgrade command and all requirements upgrade jobs are broken due to this.
-# See issue https://github.com/jazzband/pip-tools/issues/2252 for details regarding the ongoing fix.
+# See issue https://github.com/edx/devstack/issues/195 for details regarding the ongoing fix.
 # The constraint can be removed once a release (pip-tools > 7.5.1) is available with support for pip 25.3
 pip<25.3

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,7 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+
+# pip 25.x is incompatible with pip-tools 7.5.1 causing 'use_pep517' AttributeError
+# Keeping pip < 25.0 until pip-tools is updated to support pip 25.x
+pip<25.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,6 +11,8 @@
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
-# pip 25.x is incompatible with pip-tools 7.5.1 causing 'use_pep517' AttributeError
-# Keeping pip < 25.0 until pip-tools is updated to support pip 25.x
-pip<25.0
+# pip 25.3 is incompatible with pip-tools hence causing failures during the build process 
+# Make upgrade command and all requirements upgrade jobs are broken due to this.
+# See issue https://github.com/jazzband/pip-tools/issues/2252 for details regarding the ongoing fix.
+# The constraint can be removed once a release (pip-tools > 7.5.1) is available with support for pip 25.3
+pip<25.3


### PR DESCRIPTION
### Ticket
https://2u-internal.atlassian.net/browse/BOMS-277

### Summary

There is a breakage currently in pip-tools that failed several / many / all? python requirement upgrades: https://github.com/jazzband/pip-tools/issues/2252 The temporary solution may be to pin pip to the last minor version, but it does look like a fix in on the way.

### Findings

The error is stemming from the removal of the legacy setup.py bdist_wheel support in https://github.com/pypa/pip/issues/6334 which removes the optional flag --use-pip517 that had been added for the support of deprecated legacy functionality.
Since all versions of pip-tools utilize this flag for the pip-compile command, the new version pip==25.3 is now breaking with all the versions of pip-tools hence the need to pin pip as a solution for this until pip-tools provide a workaround for this issue in their next release.