### PR TITLE
fix: removed the docker images which are having no references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@
         help requirements impl-dev.clone.https impl-dev.clone.ssh impl-dev.provision \
         impl-dev.pull impl-dev.pull.without-deps impl-dev.up impl-dev.up.attach \
         impl-dev.up.without-deps selfcheck upgrade \
-        validate-lms-volume vnc-passwords
+        validate-lms-volume
 
 # Load up options (configurable through options.local.mk).
 include options.mk
@@ -551,10 +551,6 @@ validate-lms-volume: ## Validate that changes to the local workspace are reflect
 	touch $(DEVSTACK_WORKSPACE)/edx-platform/testfile
 	docker compose exec -T lms ls /edx/app/edxapp/edx-platform/testfile
 	rm $(DEVSTACK_WORKSPACE)/edx-platform/testfile
-
-vnc-passwords: ## Get the VNC passwords for the Chrome and Firefox Selenium containers.
-	@docker compose logs chrome 2>&1 | grep "VNC password" | tail -1
-	@docker compose logs firefox 2>&1 | grep "VNC password" | tail -1
 
 hadoop-application-logs-%: ## View hadoop logs by application Id.
 	docker compose exec nodemanager yarn logs -applicationId $*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,20 +14,6 @@ services:
   # Third-party services
   # ================================================
 
-  chrome:
-    container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.chrome"
-    hostname: chrome.devstack.edx
-    image: edxops/chrome:latest
-    shm_size: 2g
-    networks:
-      default:
-        aliases:
-          - edx.devstack.chrome
-    ports:
-      - "15900:5900"
-    volumes:  # for file uploads
-      - ../edx-platform/common/test/data:/edx/app/edxapp/edx-platform/common/test/data
-
   coursegraph:
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.coursegraph"
     hostname: coursegraph.devstack.edx
@@ -85,20 +71,6 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "plugins.security.disabled=true"
-
-  firefox:
-    container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.firefox"
-    hostname: firefox.devstack.edx
-    image: edxops/firefox:latest
-    shm_size: 2g
-    networks:
-      default:
-        aliases:
-          - edx.devstack.firefox
-    ports:
-      - "25900:5900"
-    volumes:  # for file uploads
-      - ../edx-platform/common/test/data:/edx/app/edxapp/edx-platform/common/test/data
 
   # Events broker
   kafka:

--- a/docs/devstack_interface.rst
+++ b/docs/devstack_interface.rst
@@ -220,4 +220,3 @@ If you want to ensure you are getting the latest listing, simply use ``make help
       selfcheck                    Check that the Makefile is free of Make syntax errors.
       upgrade                      Upgrade requirements with pip-tools.
       validate-lms-volume          Validate that changes to the local workspace are reflected in the LMS container.
-      vnc-passwords                Get the VNC passwords for the Chrome and Firefox Selenium containers.

--- a/options.mk
+++ b/options.mk
@@ -90,4 +90,4 @@ credentials+cms+discovery+ecommerce+insights+lms+registrar
 # All third-party services.
 # Separated by plus signs. Listed in alphabetical order for clarity.
 THIRD_PARTY_SERVICES ?= \
-chrome+coursegraph+elasticsearch710+firefox+memcached+mongo+mysql80+opensearch12+redis+namenode+datanode+resourcemanager+nodemanager+sparkmaster+sparkworker+vertica
+coursegraph+elasticsearch710+memcached+mongo+mysql80+opensearch12+redis+namenode+datanode+resourcemanager+nodemanager+sparkmaster+sparkworker+vertica


### PR DESCRIPTION
### Description:

1. Removed `chrome` and `firefox` docker images which are having no references and usage in `edx` org.
2. Removed related `vnc-passwords`  which we were receiving from respective containers.

### Private JIRA Link:
[BOMS-196](https://2u-internal.atlassian.net/browse/BOMS-196)

### Related PR:

- https://github.com/edx/edx-internal/pull/13602