### PR TITLE
build: Run CI on latest Ubuntu and Mac

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -23,9 +23,9 @@ jobs:
       matrix:
         os:
           - name: linux
-            image: ubuntu-24.04
+            image: ubuntu-latest
           - name: mac
-            image: macos-13
+            image: macos-latest
         python-version:
           - '3.11'
       fail-fast: false


### PR DESCRIPTION
Mac 13 runner is EOL'd.

----

I've completed each of the following or determined they are not applicable:

- [x] Made a plan to communicate any major developer interface changes (or N/A)
