### PR TITLE
fix: Migration script should also work for repos configured as "forks"

### DIFF
--- a/migrate-repo-git-to-edx.sh
+++ b/migrate-repo-git-to-edx.sh
@@ -2,8 +2,9 @@
 #
 # Migrate all enterprise repo clones from openedx to edx github org.
 #
+# If an "origin" remote is used, re-write its URL to utilize the edx repo.  If the main
+# branch tracks the "openedx" remote, re-write it to track the "edx" remote.
 #
-set -eu -o pipefail
 
 REPOS=(
   enterprise-access
@@ -33,15 +34,45 @@ fi
 for repo in "${REPOS[@]}"; do
   echo "Updating $repo ..."
   if [ ! -d "$DEVSTACK_WORKSPACE/$repo" ]; then
-    echo "Skipping $repo (not found)"
+    echo "Skipping $repo: not found"
     continue
   fi
   pushd "$DEVSTACK_WORKSPACE/$repo" >/dev/null
-  OLD_ORIGIN=$(git remote get-url origin)
-  git remote set-url origin $(git remote get-url origin | sed 's/openedx/edx/')
-  NEW_ORIGIN=$(git remote get-url origin)
-  echo "Old origin: ${OLD_ORIGIN}"
-  echo "New origin: ${NEW_ORIGIN}"
+  origin_remote_url=$(git remote get-url origin 2>/dev/null)
+  if [ -n "${origin_remote_url}" ]; then
+    # An "origin" remote has been found! Simply re-write that origin to point to "edx".
+    # Use `sed` to avoid complicated conditional logic around SSH vs. HTTPS.
+    git remote set-url origin "$(git remote get-url origin | sed 's/openedx/edx/')"
+    new_origin_remote_url=$(git remote get-url origin)
+    echo "Old origin: ${origin_remote_url}"
+    echo "New origin: ${new_origin_remote_url}"
+  else
+    # "origin" remote does not exist, so assume the main branch has been configured to
+    # point to an "openedx" remote, and an "edx" remote exists.
+    edx_remote_url=$(git remote get-url edx 2>/dev/null)
+    if [ -z "${edx_remote_url}" ]; then
+      echo "Skipping $repo: Could not find \"edx\" remote."
+      popd >/dev/null
+      continue
+    fi
+    main_branch_id=$(git rev-parse --verify --quiet main)
+    if [ -n "${main_branch_id}" ]; then
+      branch_to_update=main
+    else
+      branch_to_update=master
+    fi
+    main_branch_remote=$(git config branch.${branch_to_update}.remote)
+    if [ "${main_branch_remote}" != "edx" ]; then
+      git config branch.${branch_to_update}.remote edx
+      new_main_branch_remote=$(git config branch.${branch_to_update}.remote)
+      echo "Old tracking remote: ${main_branch_remote}"
+      echo "New tracking remote: ${new_main_branch_remote}"
+    else
+      echo "Skipping $repo: ${branch_to_update} branch was already configured to track edx remote."
+      popd >/dev/null
+      continue
+    fi
+  fi
   popd >/dev/null
   echo
 done


### PR DESCRIPTION
Previously, I had assumed all repos had an "origin" remote. This is a fatal assumption because several enterprise repos had been included in FORKED_REPOS on newer devstacks so they were configured without an "origin" remote. This fixes the migration script to handle the fork repo case---instead of re-writing the "origin" remote, re-point the main branch to track the "edx" remote instead of the "openedx" remote.

ENT-11240 (epic: ENT-11239)

Testing
---

From devstack:
```
$ make migrate-repo-git-to-edx
./migrate-repo-git-to-edx.sh
Updating enterprise-access ...
Old tracking remote: openedx
New tracking remote: edx

Updating enterprise-subsidy ...
Old tracking remote: openedx
New tracking remote: edx

Updating enterprise-catalog ...
Old tracking remote: openedx
New tracking remote: edx

Updating license-manager ...
Old tracking remote: openedx
New tracking remote: edx

Migration complete.
```

That resulted in all 4 enterprise IDA checkouts to have their main/master branches re-target the "edx" remote. Re-running the command is idempotent:

```
$ make migrate-repo-git-to-edx
./migrate-repo-git-to-edx.sh
Updating enterprise-access ...
Skipping enterprise-access: main branch was already configured to track edx remote.
Updating enterprise-subsidy ...
Skipping enterprise-subsidy: main branch was already configured to track edx remote.
Updating enterprise-catalog ...
Skipping enterprise-catalog: master branch was already configured to track edx remote.
Updating license-manager ...
Skipping license-manager: master branch was already configured to track edx remote.
Migration complete.
```