### PR TITLE
fix: added Dockerfile and config to update yarn_gpg_key

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,4 +4,5 @@ FROM mcr.microsoft.com/devcontainers/universal:latest
 
 RUN rm -f /etc/apt/sources.list.d/yarn.list \
         /etc/apt/sources.list.d/yarn*.list \
-&& apt-get update
+    && apt-get update \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/devcontainers/universal:latest
+
+# Fix: remove legacy Yarn apt repo that can break apt-get update with EXPKEYSIG
+
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+        /etc/apt/sources.list.d/yarn*.list \
+&& apt-get update

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,9 @@
     "hostRequirements": {
         "cpus": 8
     },
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
     "customizations": {
         "vscode": {
             "settings": {


### PR DESCRIPTION
### Description

Adds a custom Dev Container build to work around apt-get update failures caused by a legacy Yarn apt repository configuration.

### Changes:

- Configure the devcontainer to build from a local `.devcontainer/Dockerfile`.
- Add a `Dockerfile` that removes Yarn apt source list files before running `apt-get update`.

### Private JIRA Link:
[BOMS-394](https://2u-internal.atlassian.net/browse/BOMS-394)

### Reference PR:

- https://github.com/Azure-Samples/azure-search-openai-demo/pull/2931