### PR TITLE
fix: added comment for temporary workaround for .devcontainer build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,8 @@
 # TEMPORARY WORKAROUND:
 # This removes the legacy Yarn APT repository to unblock Codespaces pre-builds
 # failing with:
+#   GPG error: https://dl.yarnpkg.com/debian
+#   stable InRelease: The following signatures were invalid:
 #   EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
 #
 # Root cause: expired/invalid Yarn signing key in the default Microsoft

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,19 @@
+# TEMPORARY WORKAROUND:
+# This removes the legacy Yarn APT repository to unblock Codespaces pre-builds
+# failing with:
+#   EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
+#
+# Root cause: expired/invalid Yarn signing key in the default Microsoft
+# devcontainer base image causing `apt-get update` to fail and abort
+# devcontainer feature installation.
+#
+# Tracking:
+# - https://2u-internal.atlassian.net/browse/BOMS-394
+# - https://2u-internal.atlassian.net/browse/BOMS-402
+#
+# IMPORTANT: Revert this change after confirming the upstream image no longer
+# includes the broken Yarn APT configuration.
+
 FROM mcr.microsoft.com/devcontainers/universal:latest
 
 # Fix: remove legacy Yarn apt repo that can break apt-get update with EXPKEYSIG

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,23 @@
     "hostRequirements": {
         "cpus": 8
     },
+
+    /* TEMPORARY WORKAROUND:
+        This removes the legacy Yarn APT repository to unblock Codespaces pre-builds
+        failing with:
+        EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
+
+        Root cause: expired/invalid Yarn signing key in the default Microsoft
+        devcontainer base image causing `apt-get update` to fail and abort
+        devcontainer feature installation.
+
+        Tracking:
+        - https://2u-internal.atlassian.net/browse/BOMS-394
+        - https://2u-internal.atlassian.net/browse/BOMS-402
+
+        IMPORTANT: Revert this change after confirming the upstream image no longer
+        includes the broken Yarn APT configuration.*/
+
     "build": {
         "dockerfile": "Dockerfile"
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,9 @@
     /* TEMPORARY WORKAROUND:
         This removes the legacy Yarn APT repository to unblock Codespaces pre-builds
         failing with:
-        EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
+            GPG error: https://dl.yarnpkg.com/debian
+            stable InRelease: The following signatures were invalid:
+            EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
 
         Root cause: expired/invalid Yarn signing key in the default Microsoft
         devcontainer base image causing `apt-get update` to fail and abort

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,25 +2,6 @@
     "hostRequirements": {
         "cpus": 8
     },
-
-    /* TEMPORARY WORKAROUND:
-        This removes the legacy Yarn APT repository to unblock Codespaces pre-builds
-        failing with:
-            GPG error: https://dl.yarnpkg.com/debian
-            stable InRelease: The following signatures were invalid:
-            EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
-
-        Root cause: expired/invalid Yarn signing key in the default Microsoft
-        devcontainer base image causing `apt-get update` to fail and abort
-        devcontainer feature installation.
-
-        Tracking:
-        - https://2u-internal.atlassian.net/browse/BOMS-394
-        - https://2u-internal.atlassian.net/browse/BOMS-402
-
-        IMPORTANT: Revert this change after confirming the upstream image no longer
-        includes the broken Yarn APT configuration.*/
-
     "build": {
         "dockerfile": "Dockerfile"
     },


### PR DESCRIPTION
### Description:
This PR documents a temporary workaround in the devcontainer setup related to a broken Yarn APT configuration in the upstream Microsoft devcontainer base image. The comments clearly explain the root cause, link to tracking tickets, and emphasize reverting once the upstream image is fixed.

### Changes:

- Added explanatory comments at the top of `.devcontainer/Dockerfile` to document the temporary workaround and its context.