### PR TITLE
fix: enable the enterprise feature BEFORE plugins are loaded

### DIFF
--- a/configuration_files/lms.yml
+++ b/configuration_files/lms.yml
@@ -303,7 +303,7 @@ ELASTIC_SEARCH_CONFIG:
 -   host: edx.devstack.elasticsearch
     port: 9200
     use_ssl: false
-ENABLE_MKTG_SITE: true 
+ENABLE_MKTG_SITE: true
 EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend
 EMAIL_HOST: localhost
 EMAIL_HOST_PASSWORD: ''
@@ -311,6 +311,11 @@ EMAIL_HOST_USER: ''
 EMAIL_PORT: 25
 EMAIL_USE_TLS: false
 ENABLE_COMPREHENSIVE_THEMING: false
+# Enable enterprise integration.
+# See https://github.com/openedx/edx-enterprise/blob/master/docs/development.rst for
+# more background on edx-enterprise.
+# Toggle this off if you don't want anything to do with enterprise in devstack.
+ENABLE_ENTERPRISE_INTEGRATION: true
 ENTERPRISE_API_URL: http://edx.devstack.lms:18000/enterprise/api/v1
 ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES:
 - audit

--- a/py_configuration_files/lms.py
+++ b/py_configuration_files/lms.py
@@ -415,12 +415,6 @@ AUTOMATIC_AUTH_FOR_TESTING = True
 ENABLE_DISCUSSION_SERVICE = True
 SHOW_HEADER_LANGUAGE_SELECTOR = True
 
-# Enable enterprise integration by default.
-# See https://github.com/openedx/edx-enterprise/blob/master/docs/development.rst for
-# more background on edx-enterprise.
-# Toggle this off if you don't want anything to do with enterprise in devstack.
-ENABLE_ENTERPRISE_INTEGRATION = True
-
 ENABLE_MKTG_SITE = os.environ.get('ENABLE_MARKETING_SITE', False)
 
 MKTG_URLS = {


### PR DESCRIPTION
This fixes a devstack-specific bug resulting in enterprise and consent plugin settings not being loaded because the entire enterprise feature was disabled (ENABLE_ENTERPRISE_INTEGRATION = False) when the plugins were loaded.  Settings in devstack.py are loaded AFTER plugins are loaded, which makes it a bad place to flip on
ENABLE_ENTERPRISE_INTEGRATION because it would be too late.

Here's the order of operations:
1. `lms/envs/common.py` is loaded.
  a. [ENABLE_ENTERPRISE_INTEGRATION set to False](https://github.com/edx/edx-platform/blob/1f8da2659446f8a9ecaeebc537f1249757aef49f/lms/envs/common.py#L606).
  b. [add_plugins() is called](https://github.com/edx/edx-platform/blob/1f8da2659446f8a9ecaeebc537f1249757aef49f/lms/envs/common.py#L3402).
  b. `enterprise/settings/common.py` is loaded.
    1. [`plugin_settings()` exits early](https://github.com/openedx/edx-enterprise/blob/d84844fd07823559721556e091211e5ff9ec3ec7/enterprise/settings/common.py#L17-L18).
2. `lms/envs/production.py` is loaded.
  a. Loads the file `/edx/etc/lms.yml` [seeded by `configuration_files/lms.yml`](https://github.com/edx/devstack/blob/be4586c76f9cd10d58c8982e59f9da1d5d76c265/docker-compose-host.yml#L45).
  b. ENABLE_ENTERPRISE_INTEGRATION stays False **(‼️This PR updates this file to set it to True)**.
  b. `enterprise/settings/production.py` is loaded, which [re-loads common.py](https://github.com/openedx/edx-enterprise/blob/bcb5d04fa2b162788d23655409aa988e17ab7b71/enterprise/settings/production.py#L5).
    1. `plugin_settings()` exits early again because ENABLE_ENTERPRISE_INTEGRATION is still False.
3. `lms/envs/devstack.py` ([seeded by `py_configuration_files/lms.py`](https://github.com/edx/devstack/blob/be4586c76f9cd10d58c8982e59f9da1d5d76c265/docker-compose-host.yml#L47)) is loaded.
  a. FINALLY the enterprise feature is enabled, but it's too late because enterprise plugin has no devstack.py file, nor should it.

Alternatives Considered
===

* Just not exiting early inside of plugin_settings().  After all, the plugin framework docs make it pretty clear that installing a plugin pip package implies that it should be enabled---an enable flag would be redundant.  The whole point is that a integrating a plugin should be as easy as pip installing it.
  * **This approach was rejected** at least for now, mainly because we're trying to carefully and incrementally transition the edx-enterprise package from being a required dependency to an optional one.  Right now, everybody has this package installed, but not everybody wants it. We need to slowly ween operators off this package but that takes time.