### PR TITLE
build: Update macOS image version in CLI tests workflow

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -25,7 +25,7 @@ jobs:
           - name: linux
             image: ubuntu-latest
           - name: mac
-            image: macos-13
+            image: macos-15-intel
         python-version:
           - '3.11'
       fail-fast: false

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -25,6 +25,8 @@ jobs:
           - name: linux
             image: ubuntu-latest
           - name: mac
+            # Pin to GitHub's Intel macOS runner because this Docker/Colima job
+            # fails on arm64 macOS runners, including macos-latest.
             image: macos-26-intel
         python-version:
           - '3.11'

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -25,7 +25,7 @@ jobs:
           - name: linux
             image: ubuntu-latest
           - name: mac
-            image: macos-15-intel
+            image: macos-26-intel
         python-version:
           - '3.11'
       fail-fast: false


### PR DESCRIPTION
## Summary

Bumped the macOS runner label used by the CLI tests workflow from macos-13 to macos-26-intel.

## Background

The workflow was previously using `macos-13`, which is being deprecated by GitHub Actions. During the deprecation period, jobs using `macos-13` may fail because of scheduled brownouts.

PR #224 moved the workflow from `macos-13` to `macos-latest`, but `macos-latest` also failed for this workflow. The job installs Docker through Homebrew and starts Docker using Colima. On `macos-latest`, the Homebrew installation succeeds, but Colima fails while starting its VM:

```bash
error starting vm: error at 'creating and starting': exit status 1
```

Since this workflow needs a stable Intel/x86_64 macOS environment for Docker/Colima, `macos-26-intel` is the better target. GitHub also recommends `macos-26-intel` for workflows that require the Intel environment.

## Validation

Tested with `macos-26-intel`; Colima starts successfully and the Docker/Compose steps run as expected.

----

I've completed each of the following or determined they are not applicable:

- [ ] Made a plan to communicate any major developer interface changes (or N/A)
