### PR TITLE
feat: enable the Authn MFE by default

### DIFF
--- a/py_configuration_files/lms.py
+++ b/py_configuration_files/lms.py
@@ -415,6 +415,10 @@ AUTOMATIC_AUTH_FOR_TESTING = True
 ENABLE_DISCUSSION_SERVICE = True
 SHOW_HEADER_LANGUAGE_SELECTOR = True
 
+# Redirect logistration (login/registration/password reset) to the authn MFE by
+# default, matching stage/production.
+ENABLE_AUTHN_MICROFRONTEND = True
+
 ENABLE_MKTG_SITE = os.environ.get('ENABLE_MARKETING_SITE', False)
 
 MKTG_URLS = {


### PR DESCRIPTION
We've been using the Authn MFE in prod for a long time now, at least a couple years.  It's finally time to make it the default in Devstack too.