### PR TITLE
fix: dev.migrate.<service> and <service>-migrate for several services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ dev.migrate.lms:
 	docker compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && make migrate-lms'
 
 dev.migrate.%: ## Run migrations on a service.
-	docker compose exec $* bash -c 'source /edx/app/$*/$*_env && cd /edx/app/$*/$*/ && make migrate'
+	docker compose exec $* make migrate
 
 dev.drop-db: _expects-database.dev.drop-db
 

--- a/options.mk
+++ b/options.mk
@@ -76,7 +76,7 @@ analyticsapi+codejail+enterprise-subsidy+credentials+cms+cms-worker+cms_watcher+
 # Note: This list should contain _all_ db-backed services, even if not
 # configured to run; the list will be filtered later against $(DEFAULT_SERVICES).
 DB_SERVICES ?= \
-credentials+cms+discovery+ecommerce+enterprise-access+enterprise-subsidy+lms+registrar+license-manager
+credentials+cms+discovery+ecommerce+enterprise-access+enterprise-catalog+enterprise-subsidy+lms+registrar+license-manager
 
 # Services with static assets to be built.
 # Should be a subset of $(EDX_SERVICES).


### PR DESCRIPTION
Our IDA Dockerfiles are not consistent about where the app source code or virual environment is installed. Meanwhile, this mgirate target hard-codes the path which only works for half of them.  The outcome is that, e.g., `make enterprise-access-migrate` never worked and that really grinds my gears.

The fix is to just not hard-code any paths at all.

Also, add enterprise-catalog to the list of supported services for this migrate command, so `make enterprise-catalog-migrate` now works too.