### PR TITLE
fix: Finally replace awkward one-liner to create system-wide enterprise role assignments

### DIFF
--- a/enterprise/provision.sh
+++ b/enterprise/provision.sh
@@ -6,3 +6,6 @@ docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && pyth
 cat enterprise/worker_permissions.py | docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms shell --settings=devstack'
 
 docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack create_dot_application --grant-type client-credentials --client-id "enterprise-backend-service-key" --client-secret "enterprise-backend-service-secret" enterprise-backend-service enterprise_worker'
+
+# Create system wide enterprise role assignment for the enterprise service worker
+docker compose exec -T lms bash -e -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack assign_system_wide_enterprise_role --username enterprise_worker --role enterprise_openedx_operator --all-contexts'

--- a/provision-enterprise-access.sh
+++ b/provision-enterprise-access.sh
@@ -22,8 +22,7 @@ docker compose exec -T ${name} bash -e -c "echo 'from django.contrib.auth import
 ./provision-ida-user.sh ${name} ${name} ${port}
 
 # Create system wide enterprise role assignment
-# TODO: this is a pretty complex oneline, we should probably eventually convert this to a management command.
 echo -e "${GREEN}Creating system wide enterprise user role assignment for ${name}...${NC}"
-docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && echo 'from django.contrib.auth import get_user_model; from enterprise.models import SystemWideEnterpriseUserRoleAssignment, SystemWideEnterpriseRole; User = get_user_model(); worker_user = User.objects.get(username=\"${name}_worker\"); operator_role = SystemWideEnterpriseRole.objects.get(name=\"enterprise_openedx_operator\"); assignment = SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(user=worker_user, role=operator_role, applies_to_all_contexts=True);' | /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms shell" -- lms
+docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack assign_system_wide_enterprise_role --username ${name}_worker --role enterprise_openedx_operator --all-contexts"
 
 make dev.restart-devserver.enterprise-access

--- a/provision-enterprise-catalog.sh
+++ b/provision-enterprise-catalog.sh
@@ -17,9 +17,8 @@ docker compose exec -T ${name} bash -c "echo 'from django.contrib.auth import ge
 ./provision-ida-user.sh ${name} ${name} ${port}
 
 # Create system wide enterprise role assignment
-# TODO: this is a pretty complex oneline, we should probably eventually convert this to a management command.
 echo -e "${GREEN}Creating system wide enterprise user role assignment for ${name}...${NC}"
-docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && echo 'from django.contrib.auth import get_user_model; from enterprise.models import SystemWideEnterpriseUserRoleAssignment, SystemWideEnterpriseRole; User = get_user_model(); worker_user = User.objects.get(username=\"${name}_worker\"); operator_role = SystemWideEnterpriseRole.objects.get(name=\"enterprise_openedx_operator\"); assignment = SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(user=worker_user, role=operator_role, applies_to_all_contexts=True);' | /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms shell" -- lms
+docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack assign_system_wide_enterprise_role --username ${name}_worker --role enterprise_openedx_operator --all-contexts"
 
 # Restart enterprise.catalog app and worker containers
 docker compose restart enterprise-catalog enterprise-catalog-worker

--- a/provision-enterprise-subsidy.sh
+++ b/provision-enterprise-subsidy.sh
@@ -24,8 +24,7 @@ echo -e "${GREEN}Provisioning ${name}_worker in LMS...${NC}"
 ./provision-ida-user.sh ${name} ${name} ${port}
 
 # Create system wide enterprise role assignment
-# TODO: this is a pretty complex oneline, we should probably eventually convert this to a management command.
 echo -e "${GREEN}Creating system wide enterprise user role assignment for ${name}...${NC}"
-docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && echo 'from django.contrib.auth import get_user_model; from enterprise.models import SystemWideEnterpriseUserRoleAssignment, SystemWideEnterpriseRole; User = get_user_model(); worker_user = User.objects.get(username=\"${name}_worker\"); operator_role = SystemWideEnterpriseRole.objects.get(name=\"enterprise_openedx_operator\"); assignment = SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(user=worker_user, role=operator_role, applies_to_all_contexts=True);' | /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms shell" -- lms
+docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack assign_system_wide_enterprise_role --username ${name}_worker --role enterprise_openedx_operator --all-contexts"
 
 make dev.restart-devserver.enterprise-subsidy

--- a/provision-license-manager.sh
+++ b/provision-license-manager.sh
@@ -31,8 +31,7 @@ docker compose exec -T ${name} bash -e -c "echo 'from django.contrib.auth import
 ./provision-ida-user.sh ${name} ${name} $port
 
 # Create system wide enterprise role assignment
-# TODO: this is a pretty complex oneline, we should probably eventually convert this to a management command.
 echo -e "${GREEN}Creating system wide enterprise user role assignment for ${name}...${NC}"
-docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && echo 'from django.contrib.auth import get_user_model; from enterprise.models import SystemWideEnterpriseUserRoleAssignment, SystemWideEnterpriseRole; User = get_user_model(); worker_user = User.objects.get(username=\"${name}_worker\"); operator_role = SystemWideEnterpriseRole.objects.get(name=\"enterprise_openedx_operator\"); assignment = SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(user=worker_user, role=operator_role, applies_to_all_contexts=True);' | /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms shell" -- lms
+docker compose exec -T lms bash -e -c "source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack assign_system_wide_enterprise_role --username ${name}_worker --role enterprise_openedx_operator --all-contexts"
 
 make dev.restart-devserver.license-manager


### PR DESCRIPTION
This also adds one missing role assignment for the enterprise_worker user, which we always just relied on the `seed_enterprise_devstack_data` management command to do, but it really should have been here all along.

----

This PR is blocked by https://github.com/openedx/edx-enterprise/pull/2662 which actually adds the new management command.

Related:
* https://github.com/openedx/edx-enterprise/pull/2662
* https://github.com/openedx/openedx-filters/pull/337
* https://github.com/openedx/edx-enterprise/pull/2551
* https://github.com/edx/edx-platform/pull/407
* https://github.com/openedx/openedx-platform/pull/38105
* https://github.com/edx/devstack/pull/227